### PR TITLE
Improve links and list formatting for tutorials

### DIFF
--- a/docs/tutorials/01_neural_networks.ipynb
+++ b/docs/tutorials/01_neural_networks.ipynb
@@ -59,9 +59,9 @@
     "\n",
     "The QNNs in `qiskit-machine-learning` are meant as application-agnostic computational units that can be used for different use cases, and their setup will depend on the application they are needed for. The module contains an interface for the QNNs and two specific implementations:\n",
     "\n",
-    "1. [NeuralNetwork](https://qiskit.org/documentation/machine-learning/stubs/qiskit_machine_learning.neural_networks.NeuralNetwork.html): The interface for neural networks. This is an abstract class all QNNs inherit from.\n",
-    "2. [EstimatorQNN](https://qiskit.org/documentation/machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html): A network based on the evaluation of quantum mechanical observables.\n",
-    "3. [SamplerQNN](https://qiskit.org/documentation/machine-learning/locale/fr_FR/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html): A network based on the samples resulting from measuring a quantum circuit.\n",
+    "1. [NeuralNetwork](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.NeuralNetwork.html): The interface for neural networks. This is an abstract class all QNNs inherit from.\n",
+    "2. [EstimatorQNN](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html): A network based on the evaluation of quantum mechanical observables.\n",
+    "3. [SamplerQNN](https://qiskit.org/ecosystem/machine-learning/locale/fr_FR/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html): A network based on the samples resulting from measuring a quantum circuit.\n",
     "\n",
     "\n",
     "These implementations are based on the [qiskit primitives](https://qiskit.org/documentation/apidoc/primitives.html). The primitives are the entry point to run QNNs on either a simulator or real quantum hardware. Each implementation, `EstimatorQNN` and `SamplerQNN`, takes in an optional instance of its corresponding primitive, which can be any subclass of `BaseEstimator` and `BaseSampler`, respectively.\n",
@@ -72,7 +72,7 @@
     "The `NeuralNetwork` class is the interface for all QNNs available in `qiskit-machine-learning`.\n",
     "It exposes a forward and a backward pass that take data samples and trainable weights as input.\n",
     "\n",
-    "It's important to note that `NeuralNetwork`s are \"stateless\". They do not contain any training capabilities (these are pushed to the actual algorithms or applications: [classifiers](https://qiskit.org/documentation/machine-learning/apidocs/qiskit_machine_learning.algorithms.html#classifiers), [regressors](https://qiskit.org/documentation/machine-learning/apidocs/qiskit_machine_learning.algorithms.html#regressors), etc), nor do they store the values for trainable weights."
+    "It's important to note that `NeuralNetwork`s are \"stateless\". They do not contain any training capabilities (these are pushed to the actual algorithms or applications: [classifiers](https://qiskit.org/ecosystem/machine-learning/apidocs/qiskit_machine_learning.algorithms.html#classifiers), [regressors](https://qiskit.org/ecosystem/machine-learning/apidocs/qiskit_machine_learning.algorithms.html#regressors), etc), nor do they store the values for trainable weights."
    ]
   },
   {

--- a/docs/tutorials/03_quantum_kernel.ipynb
+++ b/docs/tutorials/03_quantum_kernel.ipynb
@@ -65,7 +65,7 @@
     "* $\\phi(\\vec{x})$ is the quantum feature map\n",
     "* $\\left| \\langle a|b \\rangle \\right|^{2}$ denotes the overlap of two quantum states $a$ and $b$\n",
     "\n",
-    "Quantum kernels can be plugged into common classical kernel learning algorithms such as SVMs or clustering algorithms, as you will see in the examples below. They can also be leveraged in new quantum kernel methods like `QSVC` [class](https://qiskit.org/documentation/machine-learning/stubs/qiskit_machine_learning.algorithms.QSVC.html) provided by `qiskit-machine-learning` which is explored in this tutorial, and other methods as shown in later tutorials on [Pegasos QSVC](https://github.com/qiskit-community/qiskit-machine-learning/blob/main/docs/tutorials/07_pegasos_qsvc.ipynb) and [QKA](https://github.com/qiskit-community/qiskit-machine-learning/blob/main/docs/tutorials/08_quantum_kernel_trainer.ipynb).\n",
+    "Quantum kernels can be plugged into common classical kernel learning algorithms such as SVMs or clustering algorithms, as you will see in the examples below. They can also be leveraged in new quantum kernel methods like [QSVC](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.QSVC.html) class  provided by `qiskit-machine-learning` which is explored in this tutorial, and other methods as shown in later tutorials on [Pegasos QSVC](07_pegasos_qsvc.ipynb) and [Quantum Kernel Training](08_quantum_kernel_trainer.ipynb).\n",
     "\n",
     "***\n",
     "\n",
@@ -229,11 +229,11 @@
     "\n",
     "The next step is to create a quantum kernel instance that will help classify this data. \n",
     "\n",
-    "We use the `FidelityQuantumKernel` [class](https://github.com/qiskit-community/qiskit-machine-learning/blob/main/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py), and pass two input arguments to its constructor: \n",
+    "We use the [FidelityQuantumKernel](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.kernels.FidelityQuantumKernel.html) class, and pass two input arguments to its constructor: \n",
     "\n",
-    "1. `feature_map`: in this case, a two-qubit `ZZFeatureMap` [instance](https://qiskit.org/documentation/stubs/qiskit.circuit.library.ZZFeatureMap.html).\n",
+    "1. `feature_map`: in this case, a two-qubit [ZZFeatureMap](https://qiskit.org/documentation/stubs/qiskit.circuit.library.ZZFeatureMap.html).\n",
     "\n",
-    "2. `fidelity`: in this case, the `ComputeUncompute` [fidelity](https://qiskit.org/documentation/stubs/qiskit.algorithms.state_fidelities.ComputeUncompute.html) subroutine that leverages the `Sampler` [primitive](https://qiskit.org/documentation/stubs/qiskit.primitives.Sampler.html).\n",
+    "2. `fidelity`: in this case, the [ComputeUncompute](https://qiskit.org/documentation/stubs/qiskit.algorithms.state_fidelities.ComputeUncompute.html) fidelity subroutine that leverages the [Sampler](https://qiskit.org/documentation/stubs/qiskit.primitives.Sampler.html) primitive.\n",
     "\n",
     "**NOTE:** If you don't pass a `Sampler` or `Fidelity` instance, then the instances of the reference `Sampler` and `ComputeUncompute` classes (found in `qiskit.primitives`) will be created by default."
    ]
@@ -263,7 +263,8 @@
    "metadata": {},
    "source": [
     "### 2.3. Classification with SVC\n",
-    "The quantum kernel can now be plugged into classical kernel methods, such as the `SVC` [algorithm](https://scikit-learn.org/stable/modules/svm.html) from `scikit-learn`. This algorithm allows us to define a [custom kernel](https://scikit-learn.org/stable/modules/svm.html#custom-kernels) in two ways: \n",
+    "The quantum kernel can now be plugged into classical kernel methods, such as the [SVC](https://scikit-learn.org/stable/modules/svm.html) algorithm from `scikit-learn`. This algorithm allows us to define a [custom kernel](https://scikit-learn.org/stable/modules/svm.html#custom-kernels) in two ways:\n",
+    "\n",
     "1. by providing the kernel as a **callable function**\n",
     "2. by precomputing the **kernel matrix**"
    ]
@@ -562,6 +563,7 @@
     "### 3.3. Clustering with the Spectral Clustering Model\n",
     "\n",
     "The `scikit-learn` spectral clustering algorithm allows us to define a custom kernel in two ways (just like `SVC`):\n",
+    "\n",
     "1. by providing the kernel as a **callable function**\n",
     "2. by precomputing the **kernel matrix**. \n",
     "\n",
@@ -924,7 +926,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -938,7 +940,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/04_torch_qgan.ipynb
+++ b/docs/tutorials/04_torch_qgan.ipynb
@@ -49,7 +49,7 @@
     "For further details please refer to [Quantum Generative Adversarial Networks for Learning and Loading Random Distributions](https://arxiv.org/abs/1904.00043) _Zoufal, Lucchi, Woerner_ \\[2019\\].\n",
     "\n",
     "For an example of how to use a trained qGAN in an application, the pricing of financial derivatives, please see the\n",
-    "[Option Pricing with qGANs](https://github.com/Qiskit/qiskit-finance/tree/main/docs/tutorials/10_qgan_option_pricing.ipynb) tutorial.\n",
+    "[Option Pricing with qGANs](https://qiskit.org/ecosystem/finance/tutorials/10_qgan_option_pricing.html) tutorial.\n",
     "\n",
     "## 2. Data and Representation\n",
     "\n",
@@ -769,7 +769,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -783,7 +783,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -361,7 +361,7 @@
     "In particular, we must make sure that we are returning a dense array of probabilities in the network's forward pass (`sparse=False`). This parameter is set up to `False` by default, so we just have to make sure that it has not been changed.\n",
     "\n",
     "**⚠️ Attention:** \n",
-    "If we define a custom interpret function ( in the example: `parity`), we must remember to explicitly provide the desired output shape ( in the example: `2`). For more info on the initial parameter setup for `SamplerQNN`, please check out the [official qiskit documentation](https://qiskit.org/documentation/machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html)."
+    "If we define a custom interpret function ( in the example: `parity`), we must remember to explicitly provide the desired output shape ( in the example: `2`). For more info on the initial parameter setup for `SamplerQNN`, please check out the [official qiskit documentation](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html)."
    ]
   },
   {

--- a/docs/tutorials/08_quantum_kernel_trainer.ipynb
+++ b/docs/tutorials/08_quantum_kernel_trainer.ipynb
@@ -88,7 +88,7 @@
    "source": [
     "### Prepare the Dataset\n",
     "\n",
-    "In this guide, we will use Qiskit Machine Learning's `ad_hoc.py` dataset to demonstrate the kernel training process. See the documentation [here](https://qiskit.org/documentation/machine-learning/stubs/qiskit_machine_learning.datasets.ad_hoc_data.html)."
+    "In this guide, we will use Qiskit Machine Learning's `ad_hoc.py` dataset to demonstrate the kernel training process. See the documentation [here](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.datasets.ad_hoc_data.html)."
    ]
   },
   {

--- a/docs/tutorials/09_saving_and_loading_models.ipynb
+++ b/docs/tutorials/09_saving_and_loading_models.ipynb
@@ -743,7 +743,7 @@
    "source": [
     "## 4. PyTorch hybrid models\n",
     "\n",
-    "To save and load hybrid models, when using the TorchConnector, follow the PyTorch recommendations of saving and loading the models. For more details please refer to the PyTorch Connector tutorial [here](https://qiskit.org/documentation/machine-learning/tutorials/05_torch_connector.html) where a short snippet shows how to do it.\n",
+    "To save and load hybrid models, when using the TorchConnector, follow the PyTorch recommendations of saving and loading the models. For more details please refer to the [PyTorch Connector tutorial](05_torch_connector.ipynb) where a short snippet shows how to do it.\n",
     "\n",
     "Take a look at this pseudo-like code to get the idea:\n",
     "```python\n",
@@ -818,7 +818,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

While changing urls for the repo move in #657 I noted:

>This also changed the urls similarly in `03_quantum_kernel.ipynb`. For 2 notebook references I think these would be better as relative urls so that the result ends up pointing the published html version. And for the `FidelityQuantumKernel` link that would be better to the published API ref than direct to the source. I did not change these rather I just changed all urls likewise and figured this would be better in separate PR to improve the links for it.

This PR changes the links according:
* Notebook urls are relative so if you are looking at source code, running in jupyter or looking at the published html it takes you to the corresponding context in the same folder.
* I also changed some urls to a) point at the new docs location in ecosystem and b) make the link their name rather than the generic class or primitive word next to them.

I also fixed the html formatting as a couple of lists were missing the preceding blank line that Sphinx needs to avoid all the text being just wrapped into the preceding text.



### Details and comments


