### PR TITLE
add fix for ValueError when there are multiple classes or outputs

### DIFF
--- a/qiskit_machine_learning/algorithms/objective_functions.py
+++ b/qiskit_machine_learning/algorithms/objective_functions.py
@@ -159,7 +159,7 @@ class MultiClassObjectiveFunction(ObjectiveFunction):
             # vector.
             # loss vector is a loss of a particular output value(value of i) versus true labels.
             # we do this across all samples.
-            val += probs[:, i] @ self._loss(np.full(num_samples, i), self._y)
+            val += probs[:, i] @ self._loss(np.full(num_samples, i), self._y[:, i])
         val = val / self._num_samples
 
         return val
@@ -174,7 +174,7 @@ class MultiClassObjectiveFunction(ObjectiveFunction):
         for i in range(num_outputs):
             # similar to what is in the objective, but we compute a matrix multiplication of
             # weight probability gradients and a loss vector.
-            grad += weight_prob_grad[:, i, :].T @ self._loss(np.full(num_samples, i), self._y)
+            grad += weight_prob_grad[:, i, :].T @ self._loss(np.full(num_samples, i), self._y[:, i])
 
         grad = grad / self._num_samples
         return grad


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes a ValueError in the MultiClassObjectiveFunction that occurs when a neural network needs to predict multiple classes or multiple outputs. The loss function was being passed the entire y values instead of the current iteration's target column within the y values.


### Details and comments

See also https://qiskit.slack.com/archives/CB6C24TPB/p1686792241848319?thread_ts=1686282201.761999&cid=CB6C24TPB
