### PR TITLE
Fix unit test that is breaking CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,6 +204,7 @@ jobs:
       - uses: ./.github/actions/install-machine-learning
       - name: Install Dependencies
         run: |
+          pip install jupyter
           pip install torchvision
           sudo apt-get install -y pandoc graphviz
         shell: bash

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -24,8 +24,9 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
-from qiskit.compiler.transpiler import PassManagerConfig, level_1_pass_manager, level_2_pass_manager
 from qiskit.providers.fake_provider import FakeToronto
+from qiskit.transpiler import PassManagerConfig
+from qiskit.transpiler.preset_passmanagers import level_1_pass_manager, level_2_pass_manager
 
 from qiskit_machine_learning import QiskitMachineLearningError
 from qiskit_machine_learning.neural_networks import CircuitQNN


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

CI has been failing nightly builds for a while. The error is

```
File "/Users/runner/work/qiskit-machine-learning/qiskit-machine-learning/test/neural_networks/test_circuit_qnn.py", line 27, in <module>
    from qiskit.compiler.transpiler import PassManagerConfig, level_1_pass_manager, level_2_pass_manager
ImportError: cannot import name 'PassManagerConfig' from 'qiskit.compiler.transpiler' 
```

The transpiler.py file changed in the last release of Qiskit and no  longer imports the above. The test should not have been importing them via compiler.transpiler.py (which is what it was doing) rather it should have been importing them the same way that file imported them. This changes the test case to do just that so CI should now run again (tests pass locally for me now)

I did not notice the tutorials here were failing too. I added the same workaround as we had in the other apps which gets the python3 kernel installed.

### Details and comments


