### PR TITLE
Fix CI: Module has no attribute "product"

### DIFF
--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -140,7 +140,7 @@ class NeuralNetwork(ABC):
             input_ = input_.reshape((1, -1))
         elif len(shape) > 2:
             # flatten lower dimensions, keep num_inputs as a last dimension
-            input_ = input_.reshape((np.product(input_.shape[:-1]), -1))
+            input_ = input_.reshape((np.prod(input_.shape[:-1]), -1))
 
         return input_, shape
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Nightly CI has been failing for a few days in Ubuntu Python 3.9 mypy check

>qiskit_machine_learning/neural_networks/neural_network.py:143: error: Module has no attribute "product"  [attr-defined]

Quite why just this one I am not sure. Either way `np.product` is deprecated now in numpy - elsewhere in ML it already uses `np.prod` so I just changed the failing line to that. I cannot get the same failure locally with mypy before the change - so hopefully this sorts CI. Either way we should be using np.prod now.

### Details and comments


