### PR TITLE
Fix CI: Stack overflow with new pylint 3.0.0

### DIFF
--- a/test/utils/loss_functions/test_loss_functions.py
+++ b/test/utils/loss_functions/test_loss_functions.py
@@ -73,7 +73,10 @@ class TestLossFunctions(QiskitMachineLearningTestCase):
             raise ValueError(f"Unsupported loss function: {loss_function}")
 
         # q values
-        qloss = q_loss_fun(qpredict, qtarget)
+        # Note: the numpy as array method was not here before. That loss call returns
+        # a numpy array but the pylint 3.0.0 that was just released ends up with
+        # a recursion error when accessing shape from it afterward that this circumvents.
+        qloss = np.asarray(q_loss_fun(qpredict, qtarget))
         np.testing.assert_equal(qloss.shape, loss_shape)
         qloss_sum = np.sum(q_loss_fun(qpredict, qtarget))
         qgrad = q_loss_fun.gradient(qpredict, qtarget)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Nightly CI has been failing lint across the board for a couple of nights eg.[ this job](https://github.com/qiskit-community/qiskit-machine-learning/actions/runs/6387590249/job/17336155283). pylint 3.0.0 was released a couple of days ago and linting the code ends up with a stack overflow (recursion error) that did not occur on earlier versions. For now this one line change to a test case circumvents the issue and gets CI running again without the need to pin pylint.

### Details and comments

```
pylint -rn qiskit_machine_learning test tools
Exception on node <Attribute.shape l.77 at 0x7f1824a4aad0> in file '/home/runner/work/qiskit-machine-learning/qiskit-machine-learning/test/utils/loss_functions/test_loss_functions.py'
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/astroid/decorators.py", line 90, in inner
    yield next(generator)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/astroid/decorators.py", line 44, in wrapped
    if context.push(node):
RecursionError: maximum recursion depth exceeded
```
