### PR TITLE
Improve unit test temp file usage

### DIFF
--- a/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py
+++ b/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py
@@ -106,9 +106,10 @@ class TestQSVR(QiskitMachineLearningTestCase):
         original_predicts = regressor.predict(test_features)
 
         # save/load, change the quantum instance and check if predicted values are the same
-        file_name = os.path.join(tempfile.gettempdir(), "qsvr.model")
-        regressor.save(file_name)
-        try:
+        with tempfile.TemporaryDirectory() as dir_name:
+            file_name = os.path.join(dir_name, "qsvr.model")
+            regressor.save(file_name)
+
             regressor_load = QSVR.load(file_name)
             loaded_model_predicts = regressor_load.predict(test_features)
 
@@ -122,9 +123,6 @@ class TestQSVR(QiskitMachineLearningTestCase):
 
             with self.assertRaises(TypeError):
                 FakeModel.load(file_name)
-
-        finally:
-            os.remove(file_name)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/regressors/test_qsvr.py
+++ b/test/algorithms/regressors/test_qsvr.py
@@ -105,9 +105,10 @@ class TestQSVR(QiskitMachineLearningTestCase):
         original_predicts = regressor.predict(test_features)
 
         # save/load, change the quantum instance and check if predicted values are the same
-        file_name = os.path.join(tempfile.gettempdir(), "qsvr.model")
-        regressor.save(file_name)
-        try:
+        with tempfile.TemporaryDirectory() as dir_name:
+            file_name = os.path.join(dir_name, "qsvr.model")
+            regressor.save(file_name)
+
             regressor_load = QSVR.load(file_name)
             loaded_model_predicts = regressor_load.predict(test_features)
 
@@ -121,9 +122,6 @@ class TestQSVR(QiskitMachineLearningTestCase):
 
             with self.assertRaises(TypeError):
                 FakeModel.load(file_name)
-
-        finally:
-            os.remove(file_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As it was two separate unit tests created/used the same named file in the temp directory. Running separately things are fine and are most often in CI - but CI runs tests in parallel and this has led to occasional failures[ for example in this log](https://github.com/qiskit-community/qiskit-machine-learning/actions/runs/6359217025/job/17272153307) with the relevant excerpt as below

```
==============================
Failed 2 tests - output below:
==============================

test.algorithms.regressors.test_qsvr.TestQSVR.test_save_load
------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/Users/runner/work/qiskit-machine-learning/qiskit-machine-learning/test/algorithms/regressors/test_qsvr.py", line 123, in test_save_load
    FakeModel.load(file_name)

      File "/Users/runner/work/qiskit-machine-learning/qiskit-machine-learning/qiskit_machine_learning/algorithms/serializable_model.py", line 54, in load
    model = dill.load(handler)
            ^^^^^^^^^^^^^^^^^^

      File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/dill/_dill.py", line 287, in load
    return Unpickler(file, ignore=ignore, **kwds).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

      File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/dill/_dill.py", line 442, in load
    obj = StockUnpickler.load(self)
          ^^^^^^^^^^^^^^^^^^^^^^^^^

    EOFError: Ran out of input


test.algorithms.regressors.test_fidelity_quantum_kernel_qsvr.TestQSVR.test_save_load
------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/Users/runner/work/qiskit-machine-learning/qiskit-machine-learning/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py", line 112, in test_save_load
    regressor_load = QSVR.load(file_name)
                     ^^^^^^^^^^^^^^^^^^^^

      File "/Users/runner/work/qiskit-machine-learning/qiskit-machine-learning/qiskit_machine_learning/algorithms/serializable_model.py", line 53, in load
    with open(file_name, "rb") as handler:
         ^^^^^^^^^^^^^^^^^^^^^

    FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/qsvr.model'

    
During handling of the above exception, another exception occurred:


    Traceback (most recent call last):

      File "/Users/runner/work/qiskit-machine-learning/qiskit-machine-learning/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py", line 127, in test_save_load
    os.remove(file_name)

    FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/qsvr.model'
```

### Details and comments

This changes from specific named temp file to creating a temp folder with that named file in it, same as is done in another similar test here https://github.com/qiskit-community/qiskit-machine-learning/blob/a0ea90a191932c5a7d5d125746dbb938c405554d/test/algorithms/regressors/test_neural_network_regressor.py#L187 where the temp folder is automatically removed, along with the contents, when the context ends.

This change should should eliminate that occasional random CI failures where the two tests are run at the same time and there was collision in the file used. By using a temp folder each test will have their own folder and any collision avoided from use of the same named file since they will be in different folders. This also allows multiple instances of the same test to be run in parallel, not that CI does this, but its a more general fix.
