### PR TITLE
Fixed typo in 05_torch_connector.ipynb

### DIFF
--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -599,7 +599,7 @@
     "feature_map = QuantumCircuit(1, name=\"fm\")\n",
     "feature_map.ry(param_x, 0)\n",
     "\n",
-    "# Construct simple feature map\n",
+    "# Construct simple parameterized ansatz\n",
     "param_y = Parameter(\"y\")\n",
     "ansatz = QuantumCircuit(1, name=\"vf\")\n",
     "ansatz.ry(param_y, 0)\n",


### PR DESCRIPTION
### Summary
simple feature map -> simple parameterized ansatz

### Details and comments
Changed the comment in the regression section as a simple parameterized ansatz is generated and not a simple feature map again.

