### PR TITLE
Typo in 05_torch_connector.ipynb

### DIFF
--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -599,7 +599,7 @@
     "feature_map = QuantumCircuit(1, name=\"fm\")\n",
     "feature_map.ry(param_x, 0)\n",
     "\n",
-    "# Construct simple feature map\n",
+    "# Construct simple parameterized ansatz\n",
     "param_y = Parameter(\"y\")\n",
     "ansatz = QuantumCircuit(1, name=\"vf\")\n",
     "ansatz.ry(param_y, 0)\n",


### PR DESCRIPTION
### Summary
Simple feature map -> simple parameterized ansatz


### Details and comments
There is a typo in the comments at line 602 in the regression task. A simple parameterized ansatz is initialized in the code cells and not again a feature map.

