### PR TITLE
Typo - Table of Content - 05_torch_connector.ipynb

### DIFF
--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -19,7 +19,7 @@
     "    1. Classification with PyTorch and `EstimatorQNN`\n",
     "    2. Classification with PyTorch and `SamplerQNN`\n",
     "2. [Regression](#2.-Regression)\n",
-    "    1. Regression with PyTorch and `SamplerQNN`\n",
+    "    1. Regression with PyTorch and `EstimatorQNN`\n",
     "\n",
     "[Part 2: MNIST Classification, Hybrid QNNs](#Part-2:-MNIST-Classification,-Hybrid-QNNs)\n",
     "\n",


### PR DESCRIPTION
### Summary
SamplerQNN -> EstimatorQNN


### Details and comments
In the table of contents, the Regression part is listed as Regression with SamplerQNN but in the article itself, the EstimatorQNN is used. 

