### PR TITLE
Implement evaluation mode for model evaluations

### DIFF
--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -321,6 +321,7 @@
    ],
    "source": [
     "# Evaluate model and compute accuracy\n",
+    "model1.eval()  # set model to evaluation mode\n",
     "y_predict = []\n",
     "for x, y_target in zip(X, y):\n",
     "    output = model1(Tensor(x))\n",
@@ -499,6 +500,7 @@
    ],
    "source": [
     "# Evaluate model and compute accuracy\n",
+    "model1.eval()\n",
     "y_predict = []\n",
     "for x in X:\n",
     "    output = model2(Tensor(x))\n",
@@ -704,6 +706,7 @@
     "plt.plot(X, y, \"bo\")\n",
     "\n",
     "# Plot fitted line\n",
+    "model3.eval()\n",
     "y_ = []\n",
     "for x in np.linspace(lb, ub):\n",
     "    output = model3(Tensor([x]))\n",

--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -321,7 +321,7 @@
    ],
    "source": [
     "# Evaluate model and compute accuracy\n",
-    "model1.eval()  # set model to evaluation mode\n",
+    "model1.eval()\n",
     "y_predict = []\n",
     "for x, y_target in zip(X, y):\n",
     "    output = model1(Tensor(x))\n",

--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -500,7 +500,7 @@
    ],
    "source": [
     "# Evaluate model and compute accuracy\n",
-    "model1.eval()\n",
+    "model2.eval()\n",
     "y_predict = []\n",
     "for x in X:\n",
     "    output = model2(Tensor(x))\n",


### PR DESCRIPTION
### Summary
In PART 1 of the tutorial, the classification and regression models use the model.train() setting but not the model.eval() setting with torch.no_grad().

### Details and comments
The model.eval() setting with torch.no_grad() is used in PART 2, which makes sense as no test data is used in PART 1, but for the overall understanding and the PyTorch alignment, shouldn't it be there, too? 

