### PR TITLE
Update Code in part 4

### DIFF
--- a/docs/tutorials/03_quantum_kernel.ipynb
+++ b/docs/tutorials/03_quantum_kernel.ipynb
@@ -724,7 +724,7 @@
    "outputs": [],
    "source": [
     "matrix_train = qpca_kernel.evaluate(x_vec=train_features)\n",
-    "matrix_test = qpca_kernel.evaluate(x_vec=test_features, y_vec=test_features)"
+    "matrix_test = qpca_kernel.evaluate(x_vec=test_features, y_vec=train_features)"
    ]
   },
   {
@@ -755,7 +755,7 @@
     "\n",
     "kernel_pca_q = KernelPCA(n_components=2, kernel=\"precomputed\")\n",
     "train_features_q = kernel_pca_q.fit_transform(matrix_train)\n",
-    "test_features_q = kernel_pca_q.fit_transform(matrix_test)"
+    "test_features_q = kernel_pca_qftransform(matrix_test)"
    ]
   },
   {
@@ -774,7 +774,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Logistic regression score: 1.0\n"
+      "Logistic regression score: 0.9\n"
      ]
     }
    ],

--- a/docs/tutorials/03_quantum_kernel.ipynb
+++ b/docs/tutorials/03_quantum_kernel.ipynb
@@ -755,7 +755,7 @@
     "\n",
     "kernel_pca_q = KernelPCA(n_components=2, kernel=\"precomputed\")\n",
     "train_features_q = kernel_pca_q.fit_transform(matrix_train)\n",
-    "test_features_q = kernel_pca_qftransform(matrix_test)"
+    "test_features_q = kernel_pca_q.transform(matrix_test)"
    ]
   },
   {


### PR DESCRIPTION

### Summary
Trying to fix the issue from https://github.com/qiskit-community/qiskit-machine-learning/issues/685.


### Details and comments
The issue is about the confusion of generating the test kernel matrix with only test featuresand not with the test and training features. When using that the kernel_pca needs to do fit_transform() for the testing which is not the common way, as the kernelPCA should not fit on the testing features. 

