### PR TITLE
Unpin mypy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
       - run: make lint
         shell: bash
       - run: make mypy
-        if: ${{ !cancelled() && matrix.python-version != '3.10' && matrix.python-version != 3.11 }}
+        if: ${{ !cancelled() }}
         shell: bash
       - name: Machine Learning Unit Tests under Python ${{ matrix.python-version }}
         uses: ./.github/actions/run-tests

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,3 +5,9 @@ strict_optional = False
 no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True
+
+[mypy-qiskit_machine_learning.connectors.torch_connector]
+warn_unused_ignores = False
+
+[mypy-test.connectors.test_torch_connector]
+warn_unused_ignores = False

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -143,7 +143,9 @@ def ad_hoc_data(
     for x in it.product(*[xvals] * n):
         x_arr = np.array(x)
         phi = np.sum(x_arr[:, None, None] * z_i, axis=0)
-        phi += sum(((np.pi - x_arr[i1]) * (np.pi - x_arr[i2]) * z_i[i1] @ z_i[i2] for i1, i2 in ind_pairs))
+        phi += sum(
+            ((np.pi - x_arr[i1]) * (np.pi - x_arr[i2]) * z_i[i1] @ z_i[i2] for i1, i2 in ind_pairs)
+        )
         # u_u was actually scipy.linalg.expm(1j * phi), but this method is
         # faster because phi is always a diagonal matrix.
         # We first extract the diagonal elements, then do exponentiation, then

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -141,9 +141,9 @@ def ad_hoc_data(
     ind_pairs = list(it.combinations(range(n), 2))
     _sample_total = []
     for x in it.product(*[xvals] * n):
-        x = np.array(x)
-        phi = np.sum(x[:, None, None] * z_i, axis=0)
-        phi += sum(((np.pi - x[i1]) * (np.pi - x[i2]) * z_i[i1] @ z_i[i2] for i1, i2 in ind_pairs))
+        x_arr = np.array(x)
+        phi = np.sum(x_arr[:, None, None] * z_i, axis=0)
+        phi += sum(((np.pi - x_arr[i1]) * (np.pi - x_arr[i2]) * z_i[i1] @ z_i[i2] for i1, i2 in ind_pairs))
         # u_u was actually scipy.linalg.expm(1j * phi), but this method is
         # faster because phi is always a diagonal matrix.
         # We first extract the diagonal elements, then do exponentiation, then

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ sphinxcontrib-spelling
 jupyter-sphinx
 discover
 qiskit-aer>=0.11.2
-mypy>=0.981,<1.7
+mypy>=0.981
 mypy-extensions>=0.4.3
 nbsphinx
 qiskit_sphinx_theme~=1.16.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I altered source and config to allow mypy to be unpinned as was done in #711 

For adhoc I changed the code to assign to a different variable so it does not use the same one where the type was already inferred

For torch connector. I could not find a reasonable way to support the newer 1.7.0 and earlier versions via any easy changes to the code. I decided just not to have the type ignore raise an error if its determined to be unused (which varied by version) just for the torch connector and its test file by adding extra specific configuration for that in mypy.ini

### Details and comments


