### PR TITLE
Fix copyright dates from PR #728 for 2024

### DIFF
--- a/qiskit_machine_learning/neural_networks/estimator_qnn.py
+++ b/qiskit_machine_learning/neural_networks/estimator_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/sampler_qnn.py
+++ b/qiskit_machine_learning/neural_networks/sampler_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/neural_networks/test_estimator_qnn.py
+++ b/test/neural_networks/test_estimator_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

#728 was created last year but upon merge earlier today I guess the last updated dates of the files are now 2024 when the branch of my fork, and the files that were modified at the end of 2023, were merged into main. Indeed just pulling main and running the copyright check now fails for these files. This PR simply updates the copyright dates for these so CI will pass.

```
Wrong Copyright Year:'test/neural_networks/test_estimator_qnn.py':  Current:'# (C) Copyright IBM 2022, 2023.' Correct:'# (C) Copyright IBM 2022, 2024.'
Wrong Copyright Year:'qiskit_machine_learning/neural_networks/neural_network.py':  Current:'# (C) Copyright IBM 2020, 2023.' Correct:'# (C) Copyright IBM 2020, 2024.'
Wrong Copyright Year:'qiskit_machine_learning/neural_networks/estimator_qnn.py':  Current:'# (C) Copyright IBM 2022, 2023.' Correct:'# (C) Copyright IBM 2022, 2024.'
Wrong Copyright Year:'qiskit_machine_learning/neural_networks/sampler_qnn.py':  Current:'# (C) Copyright IBM 2022, 2023.' Correct:'# (C) Copyright IBM 2022, 2024.'
```

### Details and comments


