### PR TITLE
Update intersphinx links and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ without deep quantum computing knowledge. On the other hand, Qiskit Machine Lear
 and users can easily extend it to support cutting-edge quantum machine learning research.
 
 Qiskit Machine Learning provides the
-[FidelityQuantumKernel](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.kernels.QuantumKernel.html#qiskit_machine_learning.kernels.FidelityQuantumKernel)
-class that makes use of the [Fidelity](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.state_fidelities.BaseStateFidelity.html) algorithm introduced in Qiskit and can be easily used to directly compute
-kernel matrices for given datasets or can be passed to a Quantum Support Vector Classifier 
-[QSVC](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.QSVC.html#qiskit_machine_learning.algorithms.QSVC) or
+[FidelityQuantumKernel](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.kernels.QuantumKernel.html#qiskit_machine_learning.kernels.FidelityQuantumKernel)
+class that makes use of the [Fidelity](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.state_fidelities.BaseStateFidelity.html) algorithm introduced in Qiskit Algorithms and can be easily used
+to directly compute kernel matrices for given datasets or can be passed to a Quantum Support Vector Classifier 
+[QSVC](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.QSVC.html#qiskit_machine_learning.algorithms.QSVC) or
 Quantum Support Vector Regressor
-[QSVR](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.QSVR.html#qiskit_machine_learning.algorithms.QSVR)
+[QSVR](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.QSVR.html#qiskit_machine_learning.algorithms.QSVR)
 to quickly start solving classification or regression problems.
 It also can be used with many other existing kernel-based machine learning algorithms from established
 classical frameworks.
 
 Qiskit Machine Learning defines a generic interface for neural networks that is implemented by different
 quantum neural networks. Two core implementations are readily provided, such as the
-[EstimatorQNN](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html),
-and the [SamplerQNN](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html).
-The [EstimatorQNN](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html)
+[EstimatorQNN](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html),
+and the [SamplerQNN](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html).
+The [EstimatorQNN](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html)
 leverages the [Estimator](https://qiskit.org/documentation/stubs/qiskit.primitives.BaseEstimator.html) primitive from Qiskit and 
 allows users to combine parametrized quantum circuits with quantum mechanical observables. The circuits can be constructed using, for example, building blocks
 from Qiskit’s circuit library, and the QNN’s output is given by the expected value of the observable.
-The [SamplerQNN](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html)
+The [SamplerQNN](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html)
 leverages another primitive introduced in Qiskit, the [Sampler](https://qiskit.org/documentation/stubs/qiskit.primitives.BaseSampler.html) primitive. 
 This neural network translates quasi-probabilities of bitstrings estimated by the primitive into a desired output. This 
 translation step can be used to interpret a given bitstring in a particular context, e.g. translating it into a set of classes.
@@ -35,18 +35,18 @@ translation step can be used to interpret a given bitstring in a particular cont
 The neural networks include the functionality to evaluate them for a given input as well as to compute the
 corresponding gradients, which is important for efficient training. To train and use neural networks,
 Qiskit Machine Learning provides a variety of learning algorithms such as the
-[NeuralNetworkClassifier](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.NeuralNetworkClassifier.html#qiskit_machine_learning.algorithms.NeuralNetworkClassifier)
+[NeuralNetworkClassifier](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.NeuralNetworkClassifier.html#qiskit_machine_learning.algorithms.NeuralNetworkClassifier)
 and
-[NeuralNetworkRegressor](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.NeuralNetworkRegressor.html#qiskit_machine_learning.algorithms.NeuralNetworkRegressor).
+[NeuralNetworkRegressor](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.NeuralNetworkRegressor.html#qiskit_machine_learning.algorithms.NeuralNetworkRegressor).
 Both take a QNN as input and then use it in a classification or regression context.
 To allow an easy start, two convenience implementations are provided - the Variational Quantum Classifier
-[VQC](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.VQC.html#qiskit_machine_learning.algorithms.VQC)
+[VQC](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.VQC.html#qiskit_machine_learning.algorithms.VQC)
 as well as the Variational Quantum Regressor
-[VQR](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.VQR.html#qiskit_machine_learning.algorithms.VQR).
+[VQR](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.VQR.html#qiskit_machine_learning.algorithms.VQR).
 Both take just a feature map and an ansatz and construct the underlying QNN automatically.
 
 In addition to the models provided directly in Qiskit Machine Learning, it has the
-[TorchConnector](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.connectors.TorchConnector.html#qiskit_machine_learning.connectors.TorchConnector),
+[TorchConnector](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.connectors.TorchConnector.html#qiskit_machine_learning.connectors.TorchConnector),
 which allows users to integrate all of our quantum neural networks directly into the
 [PyTorch](https://pytorch.org)
 open source machine learning library. Thanks to Qiskit’s gradient algorithms, this includes automatic
@@ -69,7 +69,7 @@ pip install qiskit-machine-learning
 If you want to work on the very latest work-in-progress versions, either to try features ahead of
 their official release or if you want to contribute to Machine Learning, then you can install from source.
 To do this follow the instructions in the
- [documentation](https://qiskit.org/ecosystem/machine-learning/getting_started.html#installation).
+ [documentation](https://qiskit-community.github.io/qiskit-machine-learning/getting_started.html#installation).
 
 
 ----------------------------------------------------------------------------------------------------
@@ -128,7 +128,7 @@ print(f"Testing accuracy: {score:0.2f}")
 ### Further examples
 
 Learning path notebooks may be found in the
-[Machine Learning tutorials](https://qiskit.org/ecosystem/machine-learning/tutorials/index.html) section
+[Machine Learning tutorials](https://qiskit-community.github.io/qiskit-machine-learning/tutorials/index.html) section
 of the documentation and are a great place to start. 
 
 Another good place to learn the fundamentals of quantum machine learning is the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,8 +183,8 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "sklearn": ("https://scikit-learn.org/stable", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
-    "qiskit-algorithms": ("https://qiskit.org/ecosystem/algorithms/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit", None),
+    "qiskit-algorithms": ("https://qiskit-community.github.io/qiskit-algorithms", None),
 }
 
 html_context = {"analytics_enabled": True}

--- a/docs/tutorials/01_neural_networks.ipynb
+++ b/docs/tutorials/01_neural_networks.ipynb
@@ -59,9 +59,9 @@
     "\n",
     "The QNNs in `qiskit-machine-learning` are meant as application-agnostic computational units that can be used for different use cases, and their setup will depend on the application they are needed for. The module contains an interface for the QNNs and two specific implementations:\n",
     "\n",
-    "1. [NeuralNetwork](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.NeuralNetwork.html): The interface for neural networks. This is an abstract class all QNNs inherit from.\n",
-    "2. [EstimatorQNN](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html): A network based on the evaluation of quantum mechanical observables.\n",
-    "3. [SamplerQNN](https://qiskit.org/ecosystem/machine-learning/locale/fr_FR/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html): A network based on the samples resulting from measuring a quantum circuit.\n",
+    "1. [NeuralNetwork](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.NeuralNetwork.html): The interface for neural networks. This is an abstract class all QNNs inherit from.\n",
+    "2. [EstimatorQNN](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.EstimatorQNN.html): A network based on the evaluation of quantum mechanical observables.\n",
+    "3. [SamplerQNN](https://qiskit-community.github.io/qiskit-machine-learning/locale/fr_FR/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html): A network based on the samples resulting from measuring a quantum circuit.\n",
     "\n",
     "\n",
     "These implementations are based on the [qiskit primitives](https://qiskit.org/documentation/apidoc/primitives.html). The primitives are the entry point to run QNNs on either a simulator or real quantum hardware. Each implementation, `EstimatorQNN` and `SamplerQNN`, takes in an optional instance of its corresponding primitive, which can be any subclass of `BaseEstimator` and `BaseSampler`, respectively.\n",
@@ -72,7 +72,7 @@
     "The `NeuralNetwork` class is the interface for all QNNs available in `qiskit-machine-learning`.\n",
     "It exposes a forward and a backward pass that take data samples and trainable weights as input.\n",
     "\n",
-    "It's important to note that `NeuralNetwork`s are \"stateless\". They do not contain any training capabilities (these are pushed to the actual algorithms or applications: [classifiers](https://qiskit.org/ecosystem/machine-learning/apidocs/qiskit_machine_learning.algorithms.html#classifiers), [regressors](https://qiskit.org/ecosystem/machine-learning/apidocs/qiskit_machine_learning.algorithms.html#regressors), etc), nor do they store the values for trainable weights."
+    "It's important to note that `NeuralNetwork`s are \"stateless\". They do not contain any training capabilities (these are pushed to the actual algorithms or applications: [classifiers](https://qiskit-community.github.io/qiskit-machine-learning/apidocs/qiskit_machine_learning.algorithms.html#classifiers), [regressors](https://qiskit-community.github.io/qiskit-machine-learning/apidocs/qiskit_machine_learning.algorithms.html#regressors), etc), nor do they store the values for trainable weights."
    ]
   },
   {

--- a/docs/tutorials/03_quantum_kernel.ipynb
+++ b/docs/tutorials/03_quantum_kernel.ipynb
@@ -65,7 +65,7 @@
     "* $\\phi(\\vec{x})$ is the quantum feature map\n",
     "* $\\left| \\langle a|b \\rangle \\right|^{2}$ denotes the overlap of two quantum states $a$ and $b$\n",
     "\n",
-    "Quantum kernels can be plugged into common classical kernel learning algorithms such as SVMs or clustering algorithms, as you will see in the examples below. They can also be leveraged in new quantum kernel methods like [QSVC](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.algorithms.QSVC.html) class  provided by `qiskit-machine-learning` which is explored in this tutorial, and other methods as shown in later tutorials on [Pegasos QSVC](07_pegasos_qsvc.ipynb) and [Quantum Kernel Training](08_quantum_kernel_trainer.ipynb).\n",
+    "Quantum kernels can be plugged into common classical kernel learning algorithms such as SVMs or clustering algorithms, as you will see in the examples below. They can also be leveraged in new quantum kernel methods like [QSVC](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.algorithms.QSVC.html) class  provided by `qiskit-machine-learning` which is explored in this tutorial, and other methods as shown in later tutorials on [Pegasos QSVC](07_pegasos_qsvc.ipynb) and [Quantum Kernel Training](08_quantum_kernel_trainer.ipynb).\n",
     "\n",
     "***\n",
     "\n",
@@ -229,11 +229,11 @@
     "\n",
     "The next step is to create a quantum kernel instance that will help classify this data. \n",
     "\n",
-    "We use the [FidelityQuantumKernel](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.kernels.FidelityQuantumKernel.html) class, and pass two input arguments to its constructor: \n",
+    "We use the [FidelityQuantumKernel](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.kernels.FidelityQuantumKernel.html) class, and pass two input arguments to its constructor: \n",
     "\n",
     "1. `feature_map`: in this case, a two-qubit [ZZFeatureMap](https://qiskit.org/documentation/stubs/qiskit.circuit.library.ZZFeatureMap.html).\n",
     "\n",
-    "2. `fidelity`: in this case, the [ComputeUncompute](https://qiskit.org/ecosystem/algorithms/stubs/qiskit_algorithms.state_fidelities.ComputeUncompute.html) fidelity subroutine that leverages the [Sampler](https://qiskit.org/documentation/stubs/qiskit.primitives.Sampler.html) primitive.\n",
+    "2. `fidelity`: in this case, the [ComputeUncompute](https://qiskit-community.github.io/qiskit-algorithms/stubs/qiskit_algorithms.state_fidelities.ComputeUncompute.html) fidelity subroutine that leverages the [Sampler](https://qiskit.org/documentation/stubs/qiskit.primitives.Sampler.html) primitive.\n",
     "\n",
     "**NOTE:** If you don't pass a `Sampler` or `Fidelity` instance, then the instances of the reference `Sampler` and `ComputeUncompute` classes (found in `qiskit.primitives`) will be created by default."
    ]

--- a/docs/tutorials/05_torch_connector.ipynb
+++ b/docs/tutorials/05_torch_connector.ipynb
@@ -358,7 +358,7 @@
     "In particular, we must make sure that we are returning a dense array of probabilities in the network's forward pass (`sparse=False`). This parameter is set up to `False` by default, so we just have to make sure that it has not been changed.\n",
     "\n",
     "**⚠️ Attention:** \n",
-    "If we define a custom interpret function ( in the example: `parity`), we must remember to explicitly provide the desired output shape ( in the example: `2`). For more info on the initial parameter setup for `SamplerQNN`, please check out the [official qiskit documentation](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html)."
+    "If we define a custom interpret function ( in the example: `parity`), we must remember to explicitly provide the desired output shape ( in the example: `2`). For more info on the initial parameter setup for `SamplerQNN`, please check out the [official qiskit documentation](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.neural_networks.SamplerQNN.html)."
    ]
   },
   {

--- a/docs/tutorials/08_quantum_kernel_trainer.ipynb
+++ b/docs/tutorials/08_quantum_kernel_trainer.ipynb
@@ -88,7 +88,7 @@
    "source": [
     "### Prepare the Dataset\n",
     "\n",
-    "In this guide, we will use Qiskit Machine Learning's `ad_hoc.py` dataset to demonstrate the kernel training process. See the documentation [here](https://qiskit.org/ecosystem/machine-learning/stubs/qiskit_machine_learning.datasets.ad_hoc_data.html)."
+    "In this guide, we will use Qiskit Machine Learning's `ad_hoc.py` dataset to demonstrate the kernel training process. See the documentation [here](https://qiskit-community.github.io/qiskit-machine-learning/stubs/qiskit_machine_learning.datasets.ad_hoc_data.html)."
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -74,7 +74,7 @@ setuptools.setup(
     },
     project_urls={
         "Bug Tracker": "https://github.com/qiskit-community/qiskit-machine-learning/issues",
-        "Documentation": "https://qiskit.org/ecosystem/machine-learning/",
+        "Documentation": "https://qiskit-community.github.io/qiskit-machine-learning/",
         "Source Code": "https://github.com/qiskit-community/qiskit-machine-learning",
     },
     zip_safe=False


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates links away from qiskit.org to the new locations for the docs

Fixes #740
Fixes #741


### Details and comments

Now that all the applications and the algorithms docs are deployed on github pages this updates the intersphinx links, in conf.py, and also urls that are coded directly in other places such as the readme and tutorials. I did not alter past release notes. There is a redirect now in effect for the former location on `qiskit.org/ecosystem` so they get to the right place.

Note that the current theme is still emitting a link to qiskit.org/ecosystem, but that will get redirected for now until such time as Qiskit/qiskit_sphinx_theme#588 is resolved and new docs are generated with such an updated theme and re-deployed.

There is one additional change in the readme, which I noticed, where it talked about `the Fidelity algorithm introduced in Qiskit` where I changed that to `... in Qiskit Algorithms`
