### PR TITLE
Make MockFidelity also compatible with Qiskit Algorithms >= 0.3.0

### DIFF
--- a/test/kernels/test_fidelity_qkernel.py
+++ b/test/kernels/test_fidelity_qkernel.py
@@ -281,6 +281,7 @@ class TestFidelityQuantumKernel(QiskitMachineLearningTestCase):
                 # just that needed for 0.3.0 and above if desired when testing against
                 # earlier algorithm versions is no longer needed or wanted.
                 from qiskit_algorithms import __version__ as algs_version
+
                 if algs_version < "0.3.0":
                     return StateFidelityResult(fidelities, [], {}, options)
                 else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #729

The BaseStateFidelity was changed in qiskit algorithms as to the type `_run` returns in order to fix a threading problem. See the above issue this fixes for more information and a link to PR done in algorithms for further detail. This updates the MockFidelity so the test using it works  with the current release of algorithms  at this time (0.2.2.), so CI passes now, and will work when algorithms releases a new version (0.3.0), which I tested locally but will not go through that path here in CI until that happens. On the slim chance it does not work (despite it working for me the altered code from algorithms main branch) then this can always be tweaked - without this change its guaranteed to fail!

### Details and comments

I noted in a comment by the change that in the future we can choose to remove present logic in the path that tests current versions as this will no longer be needed. 

I marked this as backport in order to keep stable CI passing when the new algs come out.
