### PR TITLE
Remove all other languages other than Spanish and Japanese

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,15 +138,8 @@ numfig_format = {"table": "Table %s"}
 
 translations_list = [
     ("en", "English"),
-    ("bn_BN", "Bengali"),
-    ("fr_FR", "French"),
-    ("hi_IN", "Hindi"),
     ("ja_JP", "Japanese"),
-    ("ko_KR", "Korean"),
-    ("ru_RU", "Russian"),
     ("es_UN", "Spanish"),
-    ("ta_IN", "Tamil"),
-    ("tr_TR", "Turkish"),
 ]
 language = "en"
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Spanish and Japanese are the only languages that was 100% translated & proofread as of Jan 2024

### Details and comments


