### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -112,16 +112,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12.0]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.11
+            python-version: 3.12.0
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.11
+            python-version: 3.12.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -183,7 +183,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -283,26 +283,30 @@ jobs:
           path: /tmp/u311
       - uses: actions/download-artifact@v4
         with:
+          name: ubuntu-latest-3.12.0
+          path: /tmp/u312
+      - uses: actions/download-artifact@v4
+        with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.11
-          path: /tmp/m311
+          name: macos-latest-3.12.0
+          path: /tmp/m312
       - uses: actions/download-artifact@v4
         with:
           name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.11
-          path: /tmp/w311
+          name: windows-latest-3.12.0
+          path: /tmp/w312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u38/ml.dep /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/m38/ml.dep /tmp/m311/ml.dep /tmp/w38/ml.dep /tmp/w311/ml.dep || true
+          sort -f -u /tmp/u38/ml.dep /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m38/ml.dep /tmp/m312/ml.dep /tmp/w38/ml.dep /tmp/w312/ml.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u38/ml.dat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,16 +112,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12.0]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.12.0
+            python-version: 3.12
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.12.0
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -283,7 +283,7 @@ jobs:
           path: /tmp/u311
       - uses: actions/download-artifact@v4
         with:
-          name: ubuntu-latest-3.12.0
+          name: ubuntu-latest-3.12
           path: /tmp/u312
       - uses: actions/download-artifact@v4
         with:
@@ -291,7 +291,7 @@ jobs:
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.12.0
+          name: macos-latest-3.12
           path: /tmp/m312
       - uses: actions/download-artifact@v4
         with:
@@ -299,7 +299,7 @@ jobs:
           path: /tmp/w38
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.12.0
+          name: windows-latest-3.12
           path: /tmp/w312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover

--- a/releasenotes/notes/py_3_12_support-6ac8bce3652299fb.yaml
+++ b/releasenotes/notes/py_3_12_support-6ac8bce3652299fb.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for using Qiskit Machine Learning with Python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering"
     ],
     keywords='qiskit sdk quantum machine learning ml',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Sets this min.version because of differences with env_tmp_dir env.
 minversion = 4.0.2
-envlist = py38, py39, py310, py311, lint, gpu, gpu-amd
+envlist = py38, py39, py310, py311, py312, lint, gpu, gpu-amd
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

~See #759 I will not mark this to close that since this still CI needs to use 3.12.0 specifically as the breaking change to testtools, referred there has not yet been addressed. So rather than have it close it and then open another specifically around just using 3.12 when we are able, I just put a task list in there so this does one of the entries. The other will need a release of testtools first.~ Fixed in 3.12.2 which reverted the breaking change

Closes #759

I marked this stable backport in order to facilitate a release that supports 3.12. 

See also qiskit-community/qiskit-nature#1338 if you want to see a similar change to CI to add 3.12
**Update**: qiskit-community/qiskit-nature#1341 unpins back to just 3.12

### Details and comments

If/when merged will require branch rules updating - due the changes in jobs being run now versus what was done before e.g. macos-latest 3.11 is no more as we now do macos-latest 3.12. Which jobs are Required to run/pass is configured via the Branch Rules so until that is updated there will be a mismatch. Once it is updated these will be the new rules and any existing PRs would need updating so the new rules kick in for them too.
