### PR TITLE
Pin torch==2.2.2 in CI to avoid a UTF-8 error in Windows (temporary bug in Torch)

### DIFF
--- a/.github/actions/install-machine-learning/action.yml
+++ b/.github/actions/install-machine-learning/action.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,6 +17,7 @@ runs:
   using: "composite"
   steps:
     - run : |
+        pip install torch==2.2.2
         pip install -e .[torch,sparse]
         pip install -U -c constraints.txt -r requirements-dev.txt
       shell: bash


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Pins `torch==2.2.2` in CI to avoid a UTF-8 error in Windows. This change is temporary and should be reverted to the latest Torch version as soon as https://github.com/pytorch/pytorch/issues/124897 is closed.

