### PR TITLE
[Stable] Fix test for MAC ARM and pin torch

### DIFF
--- a/.github/actions/install-machine-learning/action.yml
+++ b/.github/actions/install-machine-learning/action.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,6 +17,7 @@ runs:
   using: "composite"
   steps:
     - run : |
+        pip install torch==2.2.2
         pip install -e .[torch,sparse]
         pip install -U -c constraints.txt -r requirements-dev.txt
       shell: bash

--- a/test/algorithms/regressors/test_qsvr.py
+++ b/test/algorithms/regressors/test_qsvr.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -51,7 +51,7 @@ class TestQSVR(QiskitMachineLearningTestCase):
 
     def test_qsvr(self):
         """Test QSVR"""
-        qkernel = FidelityQuantumKernel(feature_map=self.feature_map)
+        qkernel = FidelityQuantumKernel(feature_map=self.feature_map, enforce_psd=False)
 
         qsvr = QSVR(quantum_kernel=qkernel)
         qsvr.fit(self.sample_train, self.label_train)
@@ -61,7 +61,7 @@ class TestQSVR(QiskitMachineLearningTestCase):
 
     def test_change_kernel(self):
         """Test QSVR with QuantumKernel later"""
-        qkernel = FidelityQuantumKernel(feature_map=self.feature_map)
+        qkernel = FidelityQuantumKernel(feature_map=self.feature_map, enforce_psd=False)
 
         qsvr = QSVR()
         qsvr.quantum_kernel = qkernel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Stable CI MAC is running ARM now as recent github runner changed macos_latest to ARM. While we had specifically added ARM CI to main #779 (which should be reviewed now  latest if no longer X86) it was not backported to stable, as at the time it added more CI for ARM. This fixes the test that would fail under ARM.

Also pinning torch to avoid a UTF8 issue in Windows as was done by #796.

See #800, which attempted to backport a black update and failed due to the above, which has more details on the above and links to the respective PRs and new issue around ARM and CI

### Details and comments

As this takes care of what #802 does, which does not pass CI without the test fix that is also here, that PR can simply be closed after this is merged.
