### PR TITLE
Fix lint

### DIFF
--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -13,7 +13,6 @@
 """A connector to use Qiskit (Quantum) Neural Networks as PyTorch modules."""
 from __future__ import annotations
 
-import types
 from typing import Tuple, Any, cast
 
 from string import ascii_lowercase
@@ -31,6 +30,8 @@ if _optionals.HAS_TORCH:
     from torch.autograd import Function
     from torch.nn import Module
 else:
+    import types
+
     # Dummy definition for torch module to prevent lint error about
     # possible use of torch before assignment
     torch = types.ModuleType("torch")
@@ -101,10 +102,8 @@ class TorchConnector(Module):
 
     # pylint: disable=abstract-method
     class _TorchNNFunction(Function):
-        # The possibly-used-before-assignment
 
         # pylint: disable=arguments-differ
-        # pylkint: disable=possibly-used-before-assignment
         @staticmethod
         def forward(  # type: ignore
             ctx: Any,

--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -13,6 +13,7 @@
 """A connector to use Qiskit (Quantum) Neural Networks as PyTorch modules."""
 from __future__ import annotations
 
+import types
 from typing import Tuple, Any, cast
 
 from string import ascii_lowercase
@@ -30,6 +31,9 @@ if _optionals.HAS_TORCH:
     from torch.autograd import Function
     from torch.nn import Module
 else:
+    # Dummy definition for torch module to prevent lint error about
+    # possible use of torch before assignment
+    torch = types.ModuleType("torch")
 
     class Function:  # type: ignore
         """Empty Function class
@@ -97,8 +101,10 @@ class TorchConnector(Module):
 
     # pylint: disable=abstract-method
     class _TorchNNFunction(Function):
+        # The possibly-used-before-assignment
 
         # pylint: disable=arguments-differ
+        # pylkint: disable=possibly-used-before-assignment
         @staticmethod
         def forward(  # type: ignore
             ctx: Any,

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -121,7 +121,7 @@ def ad_hoc_data(
     if n == 2:
         bitstring_parity = [bstr.count("1") % 2 for bstr in bitstrings]
         d_m = np.diag((-1) ** np.array(bitstring_parity))
-    elif n == 3:
+    else:  # n must be 3 here, as n checked above which allows only 2 and 3
         bitstring_majority = [0 if bstr.count("0") > 1 else 1 for bstr in bitstrings]
         d_m = np.diag((-1) ** np.array(bitstring_majority))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes for lint errors from latest pylint to address CI lint failures below

```
************* Module qiskit_machine_learning.datasets.ad_hoc
qiskit_machine_learning/datasets/ad_hoc.py:137:29: E0606: Possibly using variable 'd_m' before assignment (possibly-used-before-assignment)
************* Module qiskit_machine_learning.connectors.torch_connector
qiskit_machine_learning/connectors/torch_connector.py:151:36: E0606: Possibly using variable 'torch' before assignment (possibly-used-before-assignment)
```

### Details and comments

For the first error I changed the test from if/elif to if/else. With the if/elif d_m might not logically be defined, however the if switched on n which was checked earlier to assure it is only one of two values i.e. 2 or 3 so at this point the elif==3 had to be traversed if the if ==2  was not so I simply changed it to else so d_m was seen to always have been defined.

For the other error I simply added a dummy torch definition in the alternate path where the other dummy types are created for when torch is not installed.

