### PR TITLE
Fix RawFeatureVector for failing test case

### DIFF
--- a/qiskit_machine_learning/circuit/library/raw_feature_vector.py
+++ b/qiskit_machine_learning/circuit/library/raw_feature_vector.py
@@ -178,7 +178,7 @@ class ParameterizedInitialize(Instruction):
         # normalize
         norm = np.linalg.norm(cleaned_params)
         normalized = cleaned_params if np.isclose(norm, 1) else cleaned_params / norm
-Fix RawFeatire
+
         circuit = QuantumCircuit(self.num_qubits)
         circuit.initialize(normalized, range(self.num_qubits))
         self.definition = circuit

--- a/qiskit_machine_learning/circuit/library/raw_feature_vector.py
+++ b/qiskit_machine_learning/circuit/library/raw_feature_vector.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -176,8 +176,9 @@ class ParameterizedInitialize(Instruction):
                 raise QiskitError("Cannot define a ParameterizedInitialize with unbound parameters")
 
         # normalize
-        normalized = np.array(cleaned_params) / np.linalg.norm(cleaned_params)
-
+        norm = np.linalg.norm(cleaned_params)
+        normalized = cleaned_params if np.isclose(norm, 1) else cleaned_params / norm
+Fix RawFeatire
         circuit = QuantumCircuit(self.num_qubits)
         circuit.initialize(normalized, range(self.num_qubits))
         self.definition = circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #829 

### Details and comments

With this fix, the code shown in the failing sample, in the issue linked that this fixes, works fine (so does the test case). And I changed the failing sample code over to random seed whereby before it would fail quite quickly and now it passed looping 100K times in total.

Given this is just a change to internals and does not affect public API/usage I did not do a reno. Its only affecting CI and in this case its just because of some difference between a circuit we build that we expected to be the same as what the RawFeatureVector built but was not.

