### PR TITLE
Remove redundant MacOS 14 image in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9, '3.10', 3.11, 3.12]
         include:
+          # macos-latest is an Arm64 image
           - os: macos-latest
             python-version: 3.9
           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,11 +122,6 @@ jobs:
             python-version: 3.9
           - os: windows-latest
             python-version: 3.12
-          # macos-14 is an Arm64 image
-          - os: macos-14
-            python-version: '3.10'
-          - os: macos-14
-            python-version: 3.12
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -302,20 +297,12 @@ jobs:
         with:
           name: windows-latest-3.12
           path: /tmp/w312
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-14-3.10
-          path: /tmp/a310
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-14-3.12
-          path: /tmp/a312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m39/ml.dep /tmp/m312/ml.dep /tmp/w39/ml.dep /tmp/w312/ml.dep /tmp/a310/ml.dep /tmp/a312/ml.dep || true
+          sort -f -u /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m39/ml.dep /tmp/m312/ml.dep /tmp/w39/ml.dep /tmp/w312/ml.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u39/ml.dat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9, '3.10', 3.11, 3.12]
         include:
-          # macos-latest is an Arm64 image
           - os: macos-latest
             python-version: 3.9
           - os: macos-latest
@@ -122,11 +121,6 @@ jobs:
           - os: windows-latest
             python-version: 3.9
           - os: windows-latest
-            python-version: 3.12
-          # macos-latest-large is an X86 image
-          - os: macos-latest-large
-            python-version: 3.9
-          - os: macos-latest-large
             python-version: 3.12
     steps:
       - uses: actions/checkout@v4
@@ -303,20 +297,12 @@ jobs:
         with:
           name: windows-latest-3.12
           path: /tmp/w312
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-latest-large-3.9
-          path: /tmp/x39
-      - uses: actions/download-artifact@v4
-        with:
-          name: macos-latest-large-3.12
-          path: /tmp/x312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m39/ml.dep /tmp/m312/ml.dep /tmp/w39/ml.dep /tmp/w312/ml.dep /tmp/x39/ml.dep /tmp/x312/ml.dep || true
+          sort -f -u /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m39/ml.dep /tmp/m312/ml.dep /tmp/w39/ml.dep /tmp/w312/ml.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u39/ml.dat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9, '3.10', 3.11, 3.12]
         include:
+          # macos-latest is an Arm64 image
           - os: macos-latest
             python-version: 3.9
           - os: macos-latest
@@ -121,6 +122,11 @@ jobs:
           - os: windows-latest
             python-version: 3.9
           - os: windows-latest
+            python-version: 3.12
+          # macos-latest-large is an X86 image
+          - os: macos-latest-large
+            python-version: 3.9
+          - os: macos-latest-large
             python-version: 3.12
     steps:
       - uses: actions/checkout@v4
@@ -297,12 +303,20 @@ jobs:
         with:
           name: windows-latest-3.12
           path: /tmp/w312
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-latest-large-3.9
+          path: /tmp/x39
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-latest-large-3.12
+          path: /tmp/x312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m39/ml.dep /tmp/m312/ml.dep /tmp/w39/ml.dep /tmp/w312/ml.dep || true
+          sort -f -u /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/u311/ml.dep /tmp/u312/ml.dep /tmp/m39/ml.dep /tmp/m312/ml.dep /tmp/w39/ml.dep /tmp/w312/ml.dep /tmp/x39/ml.dep /tmp/x312/ml.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u39/ml.dat


### PR DESCRIPTION
Removes duplicated MacOS 14 Arm image in CI and now keeps only `macos-latest`. This change was introduced in https://github.com/qiskit-community/qiskit-machine-learning/pull/779.

Closes https://github.com/qiskit-community/qiskit-machine-learning/issues/801
Closes https://github.com/OkuyanBoga/hc-qiskit-machine-learning/issues/50