### PR TITLE
Release `nbconvert` constraint

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,1 @@
 numpy>=1.20
-nbconvert<7.14  # workaround https://github.com/jupyter/nbconvert/issues/2092
-


### PR DESCRIPTION
### Summary
Releases constraint in the `nbconvert` version due to https://github.com/jupyter/nbconvert/issues/2092, which `nbconvert` v7.16.4 may have fixed. 


### Details and comments

Closes https://github.com/qiskit-community/qiskit-machine-learning/issues/735
Closes https://github.com/OkuyanBoga/hc-qiskit-machine-learning/issues/51
