### PR TITLE
Reducing numpy version for deploy-docs.yml to fix numpy 2.0 bug

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           pip install jupyter qiskit[visualization] 'torchvision<0.10.0'
           sudo apt-get install -y pandoc graphviz
+          pip install -I numpy==1.26.4
         shell: bash
       - name: Build docs
         env:


### PR DESCRIPTION
### Summary
An issue is occurring during deploying docs using the latest numpy version for pytorch. Using the latest stable version before version 2.x might temporarily sort the issue.
