### PR TITLE
Remove `fastdtw` as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ qiskit>=1.0
 scipy>=1.4
 numpy>=1.17
 psutil>=5
-scikit-learn>=1.2.0
-fastdtw
-setuptools>=40.1.0
+scikit-learn>=1.2
+setuptools>=40.1
 dill>=0.3.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Removed `fastdtw` ([link to remote repo](https://github.com/slaypni/fastdtw)) from `requirements.txt` as it is no longer used in our codebase.

### Details and comments
Fixes https://github.com/qiskit-community/qiskit-machine-learning/issues/859
Fixes https://github.com/OkuyanBoga/hc-qiskit-machine-learning/issues/56

