### PR TITLE
Restore latest Qiskit 1.3+

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,1 @@
 numpy>=2
-qiskit<1.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Allows CI to use once again the latest Qiskit version, i.e. 1.3+.

Undoes https://github.com/qiskit-community/qiskit-machine-learning/pull/865

Fixes https://github.com/qiskit-community/qiskit-machine-learning/issues/863
Fixes https://github.com/qiskit-community/qiskit-machine-learning/issues/868


