### PR TITLE
Adhoc now supports n>3, and new arguments

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -3,6 +3,7 @@ adam
 adjoint
 ae
 aer
+aii
 al
 alan
 algo
@@ -125,13 +126,16 @@ dω
 eda
 edaspy
 egger
+eig
 eigen
+eigenbasis
 eigenphase
 eigenproblem
 eigensolver
 eigensolvers
 eigenstate
 eigenstates
+eigenvectors
 einstein
 einsum
 elif
@@ -210,6 +214,7 @@ hashable
 hatano
 havlíček
 heidelberg
+hermitian
 hessians
 hilbert
 hoc
@@ -263,8 +268,10 @@ kumar
 kwarg
 kwargs
 labelled
+labelling
 lagrange
 langle
+latin
 linux
 larrañaga
 lcu
@@ -301,6 +308,7 @@ mcry
 mcrz
 mcz
 michael
+minima
 minimised
 minimizer
 minwidth
@@ -351,6 +359,7 @@ num
 numpy
 nxd
 nxm
+o
 o'brien
 objval
 observables
@@ -379,6 +388,7 @@ parametrization
 parametrizations
 parametrize
 parametrized
+parameterized
 params
 pauli
 paulis
@@ -497,6 +507,7 @@ sklearn
 skquant
 sle
 slsqp
+sobol
 softmax
 soloviev
 spall
@@ -611,3 +622,6 @@ zz
 θ
 ψ
 ω
+φ_i
+φ_ij
+Δ

--- a/.pylintdict
+++ b/.pylintdict
@@ -43,6 +43,7 @@ benchmarking
 bergholm
 bfgs
 bielza
+bigl
 bitstring
 bitstrings
 bivariate
@@ -529,6 +530,8 @@ stefano
 steppable
 stepsize
 str
+stratifications
+stratification
 subcircuits
 subclassed
 subclasses

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import warnings
 import itertools as it
-from typing import Tuple
 
 import numpy as np
 from scipy.stats.qmc import Sobol
@@ -41,8 +40,8 @@ def ad_hoc_data(
     labelling_method: str = "expectation",
     class_labels: list | None = None,
 ) -> (
-    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    | Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
 ):
     r"""
     Generates a dataset that can be fully separated by

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
+# (C) Copyright IBM 2018, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,16 +11,16 @@
 # that they have been altered from the originals.
 
 """
-ad hoc dataset
+Ad Hoc Dataset
 """
 from __future__ import annotations
 
-from functools import reduce
+import warnings
 import itertools as it
-from typing import Tuple, Dict, List
-import numpy as np
-from sklearn import preprocessing
+from typing import Tuple
 
+import numpy as np
+from scipy.stats.qmc import Sobol
 from qiskit.utils import optionals
 
 from ..utils import algorithm_globals
@@ -31,240 +31,619 @@ def ad_hoc_data(
     training_size: int,
     test_size: int,
     n: int,
-    gap: int,
+    gap: int = 0,
     plot_data: bool = False,
     one_hot: bool = True,
     include_sample_total: bool = False,
+    entanglement: str = "full",
+    sampling_method: str = "grid",
+    divisions: int = 0,
+    labelling_method: str = "expectation",
+    class_labels: list | None = None,
 ) -> (
     Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
     | Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
 ):
-    r"""Generates a toy dataset that can be fully separated with
+    r"""
+    Generates a dataset that can be fully separated by
     :class:`~qiskit.circuit.library.ZZFeatureMap` according to the procedure
-    outlined in [1]. To construct the dataset, we first sample uniformly
-    distributed vectors :math:`\vec{x} \in (0, 2\pi]^{n}` and apply the
-    feature map
+    outlined in [1].
+
+    **Overview**
+
+    First, vectors :math:`\vec{x} \in (0, 2\pi]^{n}` are generated from a uniform
+    distribution, using a sampling method determined by the ``sampling_method``
+    argument. Next, a feature map is applied:
 
     .. math::
-        |\Phi(\vec{x})\rangle = U_{{\Phi} (\vec{x})} H^{\otimes n} U_{{\Phi} (\vec{x})}
-        H^{\otimes n} |0^{\otimes n} \rangle
+       |\Phi(\vec{x})\rangle
+       = U_{\Phi(\vec{x})} \, H^{\otimes n} \,
+         U_{\Phi(\vec{x})} \, H^{\otimes n} \, |0^{\otimes n}\rangle
 
     where
 
     .. math::
-        U_{{\Phi} (\vec{x})} = \exp \left( i \sum_{S \subseteq [n] } \phi_S(\vec{x})
-        \prod_{i \in S} Z_i \right)
+       U_{\Phi(\vec{x})}
+       = \exp\Bigl(i \sum_{S \subseteq [n]} \phi_S(\vec{x}) \prod_{i \in S} Z_i\Bigr),
 
     and
 
     .. math::
-        \begin{cases}
-        \phi_{\{i, j\}} = (\pi - x_i)(\pi - x_j) \\
-        \phi_{\{i\}} = x_i
-        \end{cases}
+       \phi_{\{i,j\}} = (\pi - x_i)(\pi - x_j), \quad
+       \phi_{\{i\}} = x_i.
 
-    We then attribute labels to the vectors according to the rule
+    The choice of second-order terms :math:`Z_i Z_j` in the sum depends on the
+    ``entanglement`` argument (e.g., ``"linear"``, ``"circular"``, or
+    ``"full"``).
+
+    An observable is then defined as
 
     .. math::
-        m(\vec{x}) = \begin{cases}
-        1 & \langle \Phi(\vec{x}) | V^\dagger \prod_i Z_i V | \Phi(\vec{x}) \rangle > \Delta \\
-        -1 & \langle \Phi(\vec{x}) | V^\dagger \prod_i Z_i V | \Phi(\vec{x}) \rangle < -\Delta
-        \end{cases}
+       O = V^\dagger \bigl(\prod_i Z_i\bigr) V,
 
-    where :math:`\Delta` is the separation gap, and
-    :math:`V\in \mathrm{SU}(4)` is a random unitary.
+    where :math:`V` is a random unitary matrix. Depending on the
+    ``labelling_method``:
 
-    The current implementation only works with n = 2 or 3.
+    - If ``"expectation"``, the expectation value
+      :math:`\langle \Phi(\vec{x})| O |\Phi(\vec{x})\rangle` is compared to the
+      gap parameter :math:`\Delta` (from ``gap``) to assign :math:`\pm 1` labels.
+    - If ``"measurement"``, a simple measurement in the computational basis is
+      performed to assign labels.
 
-    **References:**
+    **References**
 
     [1] Havlíček V, Córcoles AD, Temme K, Harrow AW, Kandala A, Chow JM,
-    Gambetta JM. Supervised learning with quantum-enhanced feature
-    spaces. Nature. 2019 Mar;567(7747):209-12.
+    Gambetta JM. *Supervised learning with quantum-enhanced feature spaces*.
+    Nature. 2019 Mar;567(7747):209–212.
     `arXiv:1804.11326 <https://arxiv.org/abs/1804.11326>`_
 
-    Args:
-        training_size: the number of training samples.
-        test_size: the number of testing samples.
-        n: number of qubits (dimension of the feature space). Must be 2 or 3.
-        gap: separation gap (:math:`\Delta`).
-        plot_data: whether to plot the data. Requires matplotlib.
-        one_hot: if True, return the data in one-hot format.
-        include_sample_total: if True, return all points in the uniform
-            grid in addition to training and testing samples.
+    Parameters
+    ----------
+    training_size : int
+        Number of training samples **per class**.
+    test_size : int
+        Number of testing samples **per class**.
+    n : int
+        Number of qubits (dimension of the feature space).
+    gap : int, optional
+        Separation gap :math:`\Delta` when ``labelling_method="expectation"``.
+        Default is 0.
+    plot_data : bool, optional
+        If True, plots the sampled data (disabled automatically if ``n > 3``).
+        Default is False.
+    one_hot : bool, optional
+        If True, returns labels in one-hot format. Default is True.
+    include_sample_total : bool, optional
+        If True, the function also returns the total number of accepted samples
+        (those that fall outside the ``\pm \Delta`` zone). Default is False.
+    entanglement : str, optional
+        Determines which second-order terms :math:`Z_i Z_j` appear in
+        :math:`U_{\Phi(\vec{x})}`. The options are:
 
-    Returns:
-        Training and testing samples.
+        * ``"linear"``: Includes terms :math:`Z_i Z_{i+1}`.
+        * ``"circular"``: Includes ``"linear"`` terms plus :math:`Z_{n-1}Z_0`.
+        * ``"full"``: Includes all pairwise terms :math:`Z_i Z_j`.
 
-    Raises:
-        ValueError: if n is not 2 or 3.
+        Default is ``"full"``.
+    sampling_method : str, optional
+        The method used to generate uniform samples :math:`\vec{x}`:
+
+        * ``"grid"``: Generates a uniform grid and selects points (supported only
+          if ``n <= 3``).
+        * ``"hypercube"``: Uses a variant of Latin hypercube sampling for
+          stratified samples.
+        * ``"sobol"``: Uses Sobol sequences.
+
+        Default is ``"grid"``.
+    divisions : int, optional
+        If ``sampling_method="hypercube"``, this parameter determines the number
+        of stratifications along each dimension. Should be chosen close to
+        ``training_size``. Default is 0 (unused by other methods).
+    labelling_method : str, optional
+        Method for assigning labels:
+
+        * ``"expectation"``: Uses the expectation value of :math:`O`.
+        * ``"measurement"``: Performs a measurement in the computational basis.
+
+        Default is ``"expectation"``.
+    class_labels : list, optional
+        Custom labels for the two classes. If not provided, the labels default to
+        ``-1`` and ``+1`` (or one-hot encoded equivalents).
+
+    Returns
+    -------
+    Tuple
+        A tuple containing:
+
+        * **training_features** : ``np.ndarray``
+        * **training_labels** : ``np.ndarray``
+        * **testing_features** : ``np.ndarray``
+        * **testing_labels** : ``np.ndarray``
+
+        If ``include_sample_total=True``, a fifth element (``int``) is included
+        that specifies the total number of accepted samples.
     """
-    class_labels = [r"A", r"B"]
-    count = 0
-    if n == 2:
-        count = 100
-    elif n == 3:
-        count = 20  # coarseness of data separation
-    else:
-        raise ValueError(f"Supported values of 'n' are 2 and 3 only, but {n} is provided.")
 
-    # Define auxiliary matrices and initial state
-    z = np.diag([1, -1])
-    i_2 = np.eye(2)
-    h_2 = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
-    h_n = reduce(np.kron, [h_2] * n)
-    psi_0 = np.ones(2**n) / np.sqrt(2**n)
+    # Default Value
+    if class_labels is None:
+        class_labels = [0, 1]
 
-    # Generate Z matrices acting on each qubits
-    z_i = np.array([reduce(np.kron, [i_2] * i + [z] + [i_2] * (n - i - 1)) for i in range(n)])
+    # Errors
+    if training_size < 0:
+        raise ValueError("Training size can't be less than 0")
+    if test_size < 0:
+        raise ValueError("Test size can't be less than 0")
+    if n <= 0:
+        raise ValueError("Number of qubits can't be less than 0")
+    if gap < 0 and labelling_method == "expectation":
+        raise ValueError("Gap can't be less than 0")
+    if entanglement not in {"linear", "circular", "full"}:
+        raise ValueError("Invalid entanglement type. Must be 'linear', 'circular', or 'full'.")
+    if sampling_method not in {"grid", "hypercube", "sobol"}:
+        raise ValueError("Invalid sampling method. Must be 'grid', 'hypercube', or 'sobol'.")
+    if divisions == 0 and sampling_method == "hypercube":
+        raise ValueError("Divisions must be set for 'hypercube' sampling.")
+    if labelling_method not in {"expectation", "measurement"}:
+        raise ValueError("Invalid labelling method. Must be 'expectation' or 'measurement'.")
+    if n > 3 and sampling_method == "grid":
+        raise ValueError("Grid sampling is unsupported for n > 3.")
 
-    # Construct the parity operator
-    bitstrings = ["".join(bstring) for bstring in it.product(*[["0", "1"]] * n)]
-    if n == 2:
-        bitstring_parity = [bstr.count("1") % 2 for bstr in bitstrings]
-        d_m = np.diag((-1) ** np.array(bitstring_parity))
-    else:  # n must be 3 here, as n checked above which allows only 2 and 3
-        bitstring_majority = [0 if bstr.count("0") > 1 else 1 for bstr in bitstrings]
-        d_m = np.diag((-1) ** np.array(bitstring_majority))
-
-    # Generate a random unitary operator by collecting eigenvectors of a
-    # random hermitian operator
-    basis = algorithm_globals.random.random(
-        (2**n, 2**n)
-    ) + 1j * algorithm_globals.random.random((2**n, 2**n))
-    basis = np.array(basis).conj().T @ np.array(basis)
-    eigvals, eigvecs = np.linalg.eig(basis)
-    idx = eigvals.argsort()[::-1]
-    eigvecs = eigvecs[:, idx]
-    m_m = eigvecs.conj().T @ d_m @ eigvecs
-
-    # Generate a grid of points in the feature space and compute the
-    # expectation value of the parity
-    xvals = np.linspace(0, 2 * np.pi, count, endpoint=False)
-    ind_pairs = list(it.combinations(range(n), 2))
-    _sample_total = []
-    for x in it.product(*[xvals] * n):
-        x_arr = np.array(x)
-        phi = np.sum(x_arr[:, None, None] * z_i, axis=0)
-        phi += sum(
-            ((np.pi - x_arr[i1]) * (np.pi - x_arr[i2]) * z_i[i1] @ z_i[i2] for i1, i2 in ind_pairs)
+    # Warnings
+    if n > 3 and plot_data:
+        warnings.warn(
+            "Plotting for n > 3 is unsupported. Disabling plot_data.",
+            UserWarning,
         )
-        # u_u was actually scipy.linalg.expm(1j * phi), but this method is
-        # faster because phi is always a diagonal matrix.
-        # We first extract the diagonal elements, then do exponentiation, then
-        # construct a diagonal matrix from them.
-        u_u = np.diag(np.exp(1j * np.diag(phi)))
-        psi = u_u @ h_n @ u_u @ psi_0
-        exp_val = np.real(psi.conj().T @ m_m @ psi)
-        if np.abs(exp_val) > gap:
-            _sample_total.append(np.sign(exp_val))
-        else:
-            _sample_total.append(0)
-    sample_total = np.array(_sample_total).reshape(*[count] * n)
+        plot_data = False
 
-    # Extract training and testing samples from grid
-    x_sample, y_sample = _sample_ad_hoc_data(sample_total, xvals, training_size + test_size, n)
+    if sampling_method == "grid" and (training_size + test_size) > 4000:
+        warnings.warn(
+            """Grid Sampling for large number of samples is not recommended 
+            and can lead to samples repeating in the training and testing sets""",
+            UserWarning,
+        )
+
+    # Initial State
+    dims = 2**n
+    psi_0 = np.ones(dims) / np.sqrt(dims)
+
+    # n-qubit Hadamard
+    h_n = _n_hadamard(n)
+
+    # Single qubit Z gates
+    z_diags = np.array([np.diag(_i_z(i, n)).reshape((1, -1)) for i in range(n)])
+
+    # Precompute ZZ Entanglements
+    zz_diags = {}
+    if entanglement == "full":
+        for i, j in it.combinations(range(n), 2):
+            zz_diags[(i, j)] = z_diags[i] * z_diags[j]
+    else:
+        for i in range(n - 1):
+            zz_diags[(i, i + 1)] = z_diags[i] * z_diags[i + 1]
+        if entanglement == "circular":
+            zz_diags[(n - 1, 0)] = z_diags[n - 1] * z_diags[0]
+
+    # n-qubit Z gate: notice that h_n[0,:] has the same elements as diagonal of z_n
+    z_n = _n_z(h_n)
+
+    # V change of basis: Eigenbasis of a random hermitian will be a random unitary
+    v = _random_unitary(dims)
+
+    # Observable for labelling boundary
+    mat_o = v.conj().T @ z_n @ v
+
+    n_samples = training_size + test_size
+
+    # Labelling Methods
+    if labelling_method == "expectation":
+
+        def _lab_fn(psi_state):
+            return _exp_label(psi_state, gap, mat_o)
+
+    else:
+        eig = np.linalg.eigh(mat_o)
+
+        def _lab_fn(psi_state):
+            return _measure(psi_state, eig)
+
+    # Sampling Methods
+    if sampling_method == "grid":
+        a_features, b_features = _grid_sampling(
+            n, n_samples, z_diags, zz_diags, psi_0, h_n, _lab_fn
+        )
+    else:
+        if sampling_method == "hypercube":
+
+            def _samp_fn(a, b):
+                return _modified_lhc(a, b, divisions)
+
+        else:
+
+            def _samp_fn(a, b):
+                return _sobol_sampling(a, b)
+
+        a_features, b_features = _loop_sampling(
+            n,
+            n_samples,
+            z_diags,
+            zz_diags,
+            psi_0,
+            h_n,
+            _lab_fn,
+            _samp_fn,
+            sampling_method,
+        )
 
     if plot_data:
-        _plot_ad_hoc_data(x_sample, y_sample, training_size)
+        _plot_ad_hoc_data(a_features, b_features, training_size)
 
-    training_input = {
-        key: (x_sample[y_sample == k, :])[:training_size] for k, key in enumerate(class_labels)
-    }
-    test_input = {
-        key: (x_sample[y_sample == k, :])[training_size : (training_size + test_size)]
-        for k, key in enumerate(class_labels)
-    }
+    res = [None] * 4
 
-    training_feature_array, training_label_array = _features_and_labels_transform(
-        training_input, class_labels, one_hot
-    )
-    test_feature_array, test_label_array = _features_and_labels_transform(
-        test_input, class_labels, one_hot
-    )
+    res[0] = np.concatenate((a_features[:training_size], b_features[:training_size]), axis=0)
+    res[2] = np.concatenate((a_features[training_size:], b_features[training_size:]), axis=0)
+    if one_hot:
+        res[1] = np.array([[1, 0]] * training_size + [[0, 1]] * training_size)
+        res[3] = np.array([[1, 0]] * test_size + [[0, 1]] * test_size)
+    else:
+        res[1] = np.array([class_labels[0]] * training_size + [class_labels[1]] * training_size)
+        res[3] = np.array([class_labels[0]] * test_size + [class_labels[1]] * test_size)
 
     if include_sample_total:
-        return (
-            training_feature_array,
-            training_label_array,
-            test_feature_array,
-            test_label_array,
-            sample_total,
-        )
-    else:
-        return (
-            training_feature_array,
-            training_label_array,
-            test_feature_array,
-            test_label_array,
-        )
+        res.append(n_samples)
 
-
-def _sample_ad_hoc_data(sample_total, xvals, num_samples, n):
-    count = sample_total.shape[0]
-    sample_a, sample_b = [], []
-    for i, sample_list in enumerate([sample_a, sample_b]):
-        label = 1 if i == 0 else -1
-        while len(sample_list) < num_samples:
-            draws = tuple(algorithm_globals.random.choice(count) for i in range(n))
-            if sample_total[draws] == label:
-                sample_list.append([xvals[d] for d in draws])
-
-    labels = np.array([0] * num_samples + [1] * num_samples)
-    samples = [sample_a, sample_b]
-    samples = np.reshape(samples, (2 * num_samples, n))
-    return samples, labels
+    return tuple(res)
 
 
 @optionals.HAS_MATPLOTLIB.require_in_call
-def _plot_ad_hoc_data(x_total, y_total, training_size):
+def _plot_ad_hoc_data(a_features: np.ndarray, b_features: np.ndarray, training_size: int) -> None:
+    """Plot the ad hoc dataset.
+
+    Args:
+        a_features (np.ndarray): Class-A feature vectors.
+        b_features (np.ndarray): Class-B feature vectors.
+        training_size (int): Number of training samples to plot.
+    """
     import matplotlib.pyplot as plt
 
-    n = x_total.shape[1]
     fig = plt.figure()
-    projection = "3d" if n == 3 else None
+    projection = "3d" if a_features.shape[1] == 3 else None
     ax1 = fig.add_subplot(1, 1, 1, projection=projection)
-    for k in range(0, 2):
-        ax1.scatter(*x_total[y_total == k][:training_size].T)
+    ax1.scatter(*a_features[:training_size].T)
+    ax1.scatter(*b_features[:training_size].T)
     ax1.set_title("Ad-hoc Data")
     plt.show()
 
 
-def _features_and_labels_transform(
-    dataset: Dict[str, np.ndarray], class_labels: List[str], one_hot: bool = True
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Converts a dataset into arrays of features and labels.
+def _n_hadamard(n: int) -> np.ndarray:
+    """Generate an n-qubit Hadamard matrix.
 
     Args:
-        dataset: A dictionary in the format of {'A': numpy.ndarray, 'B': numpy.ndarray, ...}
-        class_labels: A list of classes in the dataset
-        one_hot (bool): if True - return one-hot encoded label
+        n (int): Number of qubits.
 
     Returns:
-        A tuple of features as np.ndarray, label as np.ndarray
+        np.ndarray: The n-qubit Hadamard matrix.
     """
-    features = np.concatenate(list(dataset.values()))
+    base = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+    result = 1
+    expo = n
 
-    raw_labels = []
-    for category in dataset.keys():
-        num_samples = dataset[category].shape[0]
-        raw_labels += [category] * num_samples
+    while expo > 0:
+        if expo % 2 == 1:
+            result = np.kron(result, base)
+        base = np.kron(base, base)
+        expo //= 2
 
-    if not raw_labels:
-        # no labels, empty dataset
-        labels = np.zeros((0, len(class_labels)))
-        return features, labels
+    return result
 
-    if one_hot:
-        encoder = preprocessing.OneHotEncoder()
-        encoder.fit(np.array(class_labels).reshape(-1, 1))
-        labels = encoder.transform(np.array(raw_labels).reshape(-1, 1))
-        if not isinstance(labels, np.ndarray):
-            labels = np.array(labels.todense())
-    else:
-        encoder = preprocessing.LabelEncoder()
-        encoder.fit(np.array(class_labels))
-        labels = encoder.transform(np.array(raw_labels))
 
-    return features, labels
+def _i_z(i: int, n: int) -> np.ndarray:
+    """Create the i-th single-qubit Z gate in an n-qubit system.
+
+    Args:
+        i (int): Index of the qubit.
+        n (int): Total number of qubits.
+
+    Returns:
+        np.ndarray: The Z gate acting on the i-th qubit.
+    """
+    z = np.diag([1, -1])
+    i_1 = np.eye(2**i)
+    i_2 = np.eye(2 ** (n - i - 1))
+
+    result = np.kron(i_1, z)
+    result = np.kron(result, i_2)
+
+    return result
+
+
+def _n_z(h_n: np.ndarray) -> np.ndarray:
+    """Generate an n-qubit Z gate from the n-qubit Hadamard matrix.
+
+    Args:
+        h_n (np.ndarray): n-qubit Hadamard matrix.
+
+    Returns:
+        np.ndarray: The n-qubit Z gate.
+    """
+    res = np.diag(h_n)
+    res = np.sign(res)
+    res = np.diag(res)
+    return res
+
+
+def _modified_lhc(n: int, n_samples: int, n_div: int) -> np.ndarray:
+    """Generate samples using modified Latin Hypercube Sampling.
+
+    Args:
+        n (int): Dimensionality of the data.
+        n_samples (int): Number of samples to generate.
+        n_div (int): Number of divisions for stratified sampling.
+
+    Returns:
+        np.ndarray: Generated samples.
+    """
+    samples = np.empty((n_samples, n), dtype=float)
+    bin_size = 2 * np.pi / n_div
+    n_passes = (n_samples + n_div - 1) // n_div
+
+    all_bins = np.tile(np.arange(n_div), n_passes)
+
+    for dim in range(n):
+        algorithm_globals.random.shuffle(all_bins)
+        chosen_bins = all_bins[:n_samples]
+        offsets = algorithm_globals.random.random(n_samples)
+        samples[:, dim] = (chosen_bins + offsets) * bin_size
+
+    return samples
+
+
+def _sobol_sampling(n: int, n_samples: int) -> np.ndarray:
+    """Generate samples using Sobol sequence sampling.
+
+    Args:
+        n (int): Dimensionality of the data.
+        n_samples (int): Number of samples to generate.
+
+    Returns:
+        np.ndarray: Generated samples scaled to the interval [0, 2π].
+    """
+    sampler = Sobol(d=n, scramble=True)
+    p = 2 * np.pi * sampler.random(n_samples)
+    return p
+
+
+def _phi_i(x_vecs: np.ndarray, i: int) -> np.ndarray:
+    """Compute the φ_i term for a given dimension.
+
+    Args:
+        x_vecs (np.ndarray): Input sample vectors.
+        i (int): Dimension index.
+
+    Returns:
+        np.ndarray: Computed φ_i values.
+    """
+    return x_vecs[:, i].reshape((-1, 1))
+
+
+def _phi_ij(x_vecs: np.ndarray, i: int, j: int) -> np.ndarray:
+    """Compute the φ_ij term for given dimensions.
+
+    Args:
+        x_vecs (np.ndarray): Input sample vectors.
+        i (int): First dimension index.
+        j (int): Second dimension index.
+
+    Returns:
+        np.ndarray: Computed φ_ij values.
+    """
+    return ((np.pi - x_vecs[:, i]) * (np.pi - x_vecs[:, j])).reshape((-1, 1))
+
+
+def _random_unitary(dims):
+    a = np.array(
+        algorithm_globals.random.random((dims, dims))
+        + 1j * algorithm_globals.random.random((dims, dims))
+    )
+    herm = a.conj().T @ a
+    eigvals, eigvecs = np.linalg.eig(herm)
+    idx = eigvals.argsort()[::-1]
+    v = eigvecs[:, idx]
+    return v
+
+
+def _loop_sampling(n, n_samples, z_diags, zz_diags, psi_0, h_n, lab_fn, samp_fn, sampling_method):
+    """
+    Loop-based sampling routine to allocate feature vectors into two classes.
+
+    Args:
+        n (int): Number of qubits (feature dimension).
+        n_samples (int): Number of samples needed per class.
+        z_diags (np.ndarray): Array of single-qubit Z diagonal elements.
+        zz_diags (dict): Dictionary of ZZ-diagonal elements keyed by qubit
+            pairs.
+        O (np.ndarray): Observable for label determination.
+        psi_0 (np.ndarray): Initial state vector.
+        h_n (np.ndarray): n-qubit Hadamard matrix.
+        lab_fn (Callable): Labeling function (either expectation-based or
+            measurement-based).
+        samp_fn (Callable): Sampling function that generates feature vectors.
+        sampling_method (str): String indicating which sampling method is used
+            ("grid", "hypercube", or "sobol").
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]:
+            Two arrays of shape `(n_samples, n)`, each containing the sampled
+            feature vectors belonging to class A and class B, respectively.
+    """
+    a_features = np.empty((n_samples, n), dtype=float)
+    b_features = np.empty((n_samples, n), dtype=float)
+
+    dims = 2**n
+    a_cur, b_cur = 0, 0
+    a_needed, b_needed = n_samples, n_samples
+
+    while a_needed > 0 or b_needed > 0:
+        n_pass = a_needed + b_needed
+
+        # Sobol works better with a 2^n just above n_pass
+        if sampling_method == "sobol":
+            n_pass = 2 ** ((n_pass - 1).bit_length())
+
+        # Stratified Sampling for x vector
+        x_vecs = samp_fn(n, n_pass)
+
+        pre_exp = np.zeros((n_pass, dims))
+
+        # First Order Terms
+        for i in range(n):
+            pre_exp += _phi_i(x_vecs, i) * z_diags[i]
+
+        # Second Order Terms
+        for i, j in zz_diags.keys():
+            pre_exp += _phi_ij(x_vecs, i, j) * zz_diags[(i, j)]
+
+        # Since pre_exp is purely diagonal, exp(A) = diag(exp(Aii))
+        post_exp = np.exp(1j * pre_exp)
+        uphi = np.zeros((n_pass, dims, dims), dtype=post_exp.dtype)
+        cols = range(dims)
+        uphi[:, cols, cols] = post_exp[:, cols]
+
+        psi = (uphi @ h_n @ uphi @ psi_0).reshape((-1, dims, 1))
+
+        # Labelling
+        raw_labels = lab_fn(psi)
+
+        if a_needed > 0:
+            a_indx = raw_labels == 1
+            a_count = min(int(np.sum(a_indx)), a_needed)
+            a_features[a_cur : a_cur + a_count] = x_vecs[a_indx][:a_count]
+            a_cur += a_count
+            a_needed -= a_count
+
+        if b_needed > 0:
+            b_indx = raw_labels == -1
+            b_count = min(int(np.sum(b_indx)), b_needed)
+            b_features[b_cur : b_cur + b_count] = x_vecs[b_indx][:b_count]
+            b_cur += b_count
+            b_needed -= b_count
+
+    return a_features, b_features
+
+
+def _exp_label(psi, gap, mat_o):
+    """
+    Compute labels by comparing the expectation value of an observable to a gap.
+
+    Args:
+        psi (np.ndarray): Array of shape `(num_samples, dim, 1)` containing
+            the statevectors for each sample.
+        gap (float): Separation gap (Δ). If the absolute expectation exceeds
+            this, the sample is labeled ±1 based on the sign.
+        O (np.ndarray): Observable used for label determination.
+
+    Returns:
+        np.ndarray: Labels for each sample. Values will be -1, 0, or +1, where
+        0 indicates an expectation value within the gap zone (not exceeding ±gap).
+    """
+    psi_dag = np.transpose(psi.conj(), (0, 2, 1))
+    exp_val = np.real(psi_dag @ mat_o @ psi).flatten()
+    labels = (np.abs(exp_val) > gap) * (np.sign(exp_val))
+    return labels
+
+
+def _measure(psi, eig):
+    """
+    Compute labels by simulating a measurement of the observable on each state.
+
+    The eigen-decomposition of O is used as the measurement basis. Each state
+    is projected onto one of the eigenvectors, and labels are set to the
+    corresponding eigenvalue.
+
+    Args:
+        psi (np.ndarray): Array of shape `(num_samples, dim, 1)` containing
+            the statevectors for each sample.
+        eig (np.ndarray): Eigenvalues of Observable to be 'measured'
+
+    Returns:
+        np.ndarray: Labels for each sample, set to one of the eigenvalues
+        of the observable O.
+    """
+    eigenvalues, eigenvectors = eig
+    eigshape = eigenvectors.shape
+    new_psi = eigenvectors.T.conj().reshape((1, eigshape[1], eigshape[0])) @ psi
+
+    probab = np.abs(new_psi) ** 2
+    toss = algorithm_globals.random.random((psi.shape[0], 1))
+    cum_probab = np.cumsum(probab, axis=1).reshape(psi.shape[0], -1)
+    collapsed = (cum_probab >= toss).argmax(axis=-1, keepdims=True)
+    labels = eigenvalues[collapsed.flatten()]
+
+    return np.sign(labels)
+
+
+def _grid_sampling(n, n_samples, z_diags, zz_diags, psi_0, h_n, lab_fn):
+    """
+    Generate feature vectors from a uniform grid (only supported for `n <= 3`)
+    and assign labels using the specified labeling function.
+
+    Args:
+        n (int): Number of qubits (dimension).
+        n_samples (int): Number of samples needed per class.
+        z_diags (np.ndarray): Array of single-qubit Z diagonal elements.
+        zz_diags (dict): Dictionary of ZZ-diagonal elements keyed by qubit pairs.
+        psi_0 (np.ndarray): Initial state vector.
+        h_n (np.ndarray): n-qubit Hadamard matrix.
+        lab_fn (Callable): Labeling function (either expectation-based or
+            measurement-based).
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]:
+            Two arrays of shape `(n_samples, n)`, each containing the sampled
+            feature vectors belonging to class A and class B, respectively.
+            This code is incomplete and references variables not defined above,
+            so the returned arrays are empty placeholders by default.
+    """
+
+    count = 1
+    if n == 1:
+        count = 5000
+    elif n == 2:
+        count = 100
+    elif n == 3:
+        count = 20
+
+    xvals = np.linspace(0, 2 * np.pi, count, endpoint=False)
+    grid_labels = []
+
+    # Loop through uniform grid
+    for x in it.product(*[xvals] * n):
+        x_arr = np.array(x)
+        pre_exp = 0
+        for i in range(n):
+            pre_exp += x_arr[i] * z_diags[i]
+        for i, j in zz_diags.keys():
+            pre_exp += ((np.pi - x_arr[i]) * (np.pi - x_arr[j])) * zz_diags[(i, j)]
+
+        uphi = np.diag(np.exp(1j * pre_exp.flatten()))
+        psi = uphi @ h_n @ uphi @ psi_0
+        label = lab_fn(psi.reshape((1, -1, 1)))
+
+        grid_labels.append(label)
+
+    grid_labels = np.array(grid_labels).reshape(*[count] * n)
+
+    count = grid_labels.shape[0]
+    a_features, b_features = [], []
+
+    while len(a_features) < n_samples:
+        draws = tuple(algorithm_globals.random.choice(count) for _ in range(n))
+        if grid_labels[draws] == 1:
+            a_features.append([xvals[d] for d in draws])
+
+    while len(b_features) < n_samples:
+        draws = tuple(algorithm_globals.random.choice(count) for _ in range(n))
+        if grid_labels[draws] == -1:
+            b_features.append([xvals[d] for d in draws])
+
+    return np.array(a_features), np.array(b_features)

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -288,10 +288,10 @@ def ad_hoc_data(
         y_test = np.array([class_labels[0]] * test_size + [class_labels[1]] * test_size)
 
     if include_sample_total:
-        samples = np.array([include_sample_total])
+        samples = np.array([n_samples * 2])
         return (x_train, y_train, x_test, y_test, samples)
 
-    return (x_train, y_train, x_test, y_test, samples)
+    return (x_train, y_train, x_test, y_test)
 
 
 @optionals.HAS_MATPLOTLIB.require_in_call

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -278,21 +278,20 @@ def ad_hoc_data(
     if plot_data:
         _plot_ad_hoc_data(a_features, b_features, training_size)
 
-    res = [None] * 4
-
-    res[0] = np.concatenate((a_features[:training_size], b_features[:training_size]), axis=0)
-    res[2] = np.concatenate((a_features[training_size:], b_features[training_size:]), axis=0)
+    x_train = np.concatenate((a_features[:training_size], b_features[:training_size]), axis=0)
+    x_test = np.concatenate((a_features[training_size:], b_features[training_size:]), axis=0)
     if one_hot:
-        res[1] = np.array([[1, 0]] * training_size + [[0, 1]] * training_size)
-        res[3] = np.array([[1, 0]] * test_size + [[0, 1]] * test_size)
+        y_train = np.array([[1, 0]] * training_size + [[0, 1]] * training_size)
+        y_test = np.array([[1, 0]] * test_size + [[0, 1]] * test_size)
     else:
-        res[1] = np.array([class_labels[0]] * training_size + [class_labels[1]] * training_size)
-        res[3] = np.array([class_labels[0]] * test_size + [class_labels[1]] * test_size)
+        y_train = np.array([class_labels[0]] * training_size + [class_labels[1]] * training_size)
+        y_test = np.array([class_labels[0]] * test_size + [class_labels[1]] * test_size)
 
     if include_sample_total:
-        res.append(n_samples)
+        samples = np.array([include_sample_total])
+        return (x_train, y_train, x_test, y_test, samples)
 
-    return tuple(res)
+    return (x_train, y_train, x_test, y_test, samples)
 
 
 @optionals.HAS_MATPLOTLIB.require_in_call
@@ -325,7 +324,7 @@ def _n_hadamard(n: int) -> np.ndarray:
         np.ndarray: The n-qubit Hadamard matrix.
     """
     base = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
-    result = 1
+    result = np.eye(1)
     expo = n
 
     while expo > 0:

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -47,12 +47,8 @@ def ad_hoc_data(
     r"""
     Generates a dataset that can be fully separated by
     :class:`~qiskit.circuit.library.ZZFeatureMap` according to the procedure
-    outlined in [1].
-
-    **Overview**
-
-    First, vectors :math:`\vec{x} \in (0, 2\pi]^{n}` are generated from a uniform
-    distribution, using a sampling method determined by the ``sampling_method``
+    outlined in [1]. First, vectors :math:`\vec{x} \in (0, 2\pi]^{n}` are generated from a 
+    uniform distribution, using a sampling method determined by the ``sampling_method``
     argument. Next, a feature map is applied:
 
     .. math::
@@ -69,98 +65,81 @@ def ad_hoc_data(
     and
 
     .. math::
-       \phi_{\{i,j\}} = (\pi - x_i)(\pi - x_j), \quad
-       \phi_{\{i\}} = x_i.
+        \begin{cases}\phi_{\{i, j\}} = (\pi - x_i)(\pi - x_j) \\
+        \phi_{\{i\}} = x_i \end{cases}
 
-    The choice of second-order terms :math:`Z_i Z_j` in the sum depends on the
-    ``entanglement`` argument (e.g., ``"linear"``, ``"circular"``, or
-    ``"full"``).
+    The choice of second-order terms :math:`Z_i Z_j` in the above summation depends 
+    on the ``entanglement`` argument (``"linear"``, ``"circular"``, or
+    ``"full"``). See arguments for more information.
 
     An observable is then defined as
 
     .. math::
-       O = V^\dagger \bigl(\prod_i Z_i\bigr) V,
+       O = V^\dagger \bigl(\prod_i Z_i\bigr) V
 
-    where :math:`V` is a random unitary matrix. Depending on the
-    ``labelling_method``:
+    where :math:`V` is a randomly generated unitary matrix. Depending on the
+    ``labelling_method``, if ``"expectation"`` is used, the expectation value
+    :math:`\langle \Phi(\vec{x})| O |\Phi(\vec{x})\rangle` is compared to the
+    gap parameter :math:`\Delta` (from ``gap``) to assign :math:`\pm 1` labels. 
+    if ``"measurement"`` is used, a simple measurement in the computational 
+    basis is performed to assign labels.
 
-    - If ``"expectation"``, the expectation value
-      :math:`\langle \Phi(\vec{x})| O |\Phi(\vec{x})\rangle` is compared to the
-      gap parameter :math:`\Delta` (from ``gap``) to assign :math:`\pm 1` labels.
-    - If ``"measurement"``, a simple measurement in the computational basis is
-      performed to assign labels.
-
-    **References**
+    **References:**
 
     [1] Havlíček V, Córcoles AD, Temme K, Harrow AW, Kandala A, Chow JM,
     Gambetta JM. *Supervised learning with quantum-enhanced feature spaces*.
     Nature. 2019 Mar;567(7747):209–212.
     `arXiv:1804.11326 <https://arxiv.org/abs/1804.11326>`_
 
-    Parameters
-    ----------
-    training_size : int
-        Number of training samples **per class**.
-    test_size : int
-        Number of testing samples **per class**.
-    n : int
-        Number of qubits (dimension of the feature space).
-    gap : int, optional
-        Separation gap :math:`\Delta` when ``labelling_method="expectation"``.
-        Default is 0.
-    plot_data : bool, optional
-        If True, plots the sampled data (disabled automatically if ``n > 3``).
-        Default is False.
-    one_hot : bool, optional
-        If True, returns labels in one-hot format. Default is True.
-    include_sample_total : bool, optional
-        If True, the function also returns the total number of accepted samples
-        (those that fall outside the ``\pm \Delta`` zone). Default is False.
-    entanglement : str, optional
-        Determines which second-order terms :math:`Z_i Z_j` appear in
-        :math:`U_{\Phi(\vec{x})}`. The options are:
+    Parameters:
+        training_size : Number of training samples per class.
+        test_size :  Number of testing samples per class.
+        n : Number of qubits (dimension of the feature space).
+        gap : Separation gap :math:`\Delta` used when ``labelling_method="expectation"``.
+            Default is 0.
+        plot_data : If True, plots the sampled data (disabled automatically if 
+            ``n > 3``). Default is False.
+        one_hot : If True, returns labels in one-hot format. Default is True.
+        include_sample_total : If True, the function also returns the total number 
+            of accepted samples. Default is False.
+        entanglement : Determines which second-order terms :math:`Z_i Z_j` appear in
+            :math:`U_{\Phi(\vec{x})}`. The options are:
 
-        * ``"linear"``: Includes terms :math:`Z_i Z_{i+1}`.
-        * ``"circular"``: Includes ``"linear"`` terms plus :math:`Z_{n-1}Z_0`.
-        * ``"full"``: Includes all pairwise terms :math:`Z_i Z_j`.
+                * ``"linear"``: Includes terms :math:`Z_i Z_{i+1}`.
+                * ``"circular"``: Includes ``"linear"`` terms plus :math:`Z_{n-1}Z_0`.
+                * ``"full"``: Includes all pairwise terms :math:`Z_i Z_j`.
 
-        Default is ``"full"``.
-    sampling_method : str, optional
-        The method used to generate uniform samples :math:`\vec{x}`:
+            Default is ``"full"``.
+        sampling_method: The method used to generate uniform samples :math:`\vec{x}`.
+            Choices are:
 
-        * ``"grid"``: Generates a uniform grid and selects points (supported only
-          if ``n <= 3``).
-        * ``"hypercube"``: Uses a variant of Latin hypercube sampling for
-          stratified samples.
-        * ``"sobol"``: Uses Sobol sequences.
+                * ``"grid"``: Chooses points from a uniform grid (supported only if ``n <= 3``)
+                * ``"hypercube"``: Uses a variant of Latin Hypercube sampling for stratification
+                * ``"sobol"``: Uses Sobol sequences
 
-        Default is ``"grid"``.
-    divisions : int, optional
-        If ``sampling_method="hypercube"``, this parameter determines the number
-        of stratifications along each dimension. Should be chosen close to
-        ``training_size``. Default is 0 (unused by other methods).
-    labelling_method : str, optional
-        Method for assigning labels:
+            Default is ``"grid"``.
+        divisions : Must be specified if ``sampling_method="hypercube"``. This parameter 
+            determines the number of stratifications along each dimension. Recommened 
+            to be chosen close to ``training_size``. 
+        labelling_method : Method for assigning labels. The options are:
 
-        * ``"expectation"``: Uses the expectation value of :math:`O`.
-        * ``"measurement"``: Performs a measurement in the computational basis.
+                * ``"expectation"``: Uses the expectation value of the observable.
+                * ``"measurement"``: Performs a measurement in the computational basis.
 
-        Default is ``"expectation"``.
-    class_labels : list, optional
-        Custom labels for the two classes. If not provided, the labels default to
-        ``-1`` and ``+1`` (or one-hot encoded equivalents).
+            Default is ``"expectation"``.
+        class_labels : Custom labels for the two classes when one-hot is not enabled. 
+            If not provided, the labels default to ``-1`` and ``+1``
 
-    Returns
-    -------
-    Tuple
-        A tuple containing:
+    Returns:
+        Tuple
+        containing the following:
 
         * **training_features** : ``np.ndarray``
         * **training_labels** : ``np.ndarray``
         * **testing_features** : ``np.ndarray``
         * **testing_labels** : ``np.ndarray``
 
-        If ``include_sample_total=True``, a fifth element (``int``) is included
+        If ``include_sample_total=True``, a fifth element (``np.ndarray``) is included
         that specifies the total number of accepted samples.
     """
 
@@ -174,7 +153,7 @@ def ad_hoc_data(
     if test_size < 0:
         raise ValueError("Test size can't be less than 0")
     if n <= 0:
-        raise ValueError("Number of qubits can't be less than 0")
+        raise ValueError("Number of qubits can't be less than 1")
     if gap < 0 and labelling_method == "expectation":
         raise ValueError("Gap can't be less than 0")
     if entanglement not in {"linear", "circular", "full"}:

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -119,7 +119,7 @@ def ad_hoc_data(
 
             Default is ``"grid"``.
         divisions : Must be specified if ``sampling_method="hypercube"``. This parameter 
-            determines the number of stratifications along each dimension. Recommened 
+            determines the number of stratifications along each dimension. Recommended 
             to be chosen close to ``training_size``. 
         labelling_method : Method for assigning labels. The options are:
 

--- a/releasenotes/notes/feature-ad_hoc_data_multiqubit-b16eb32337e7959d.yaml
+++ b/releasenotes/notes/feature-ad_hoc_data_multiqubit-b16eb32337e7959d.yaml
@@ -1,0 +1,21 @@
+
+features:
+  - |
+    The :class:`~qiskit_machine_learning.datasets.ad_hoc_data` class now supports more than
+    three qubits. It also now supports multiple sampling methods, linear/circular/full
+    entanglements and also both expectation-based and measurement-based labelling.
+
+    Example of a 4-qubit dataset with the new features:
+
+    .. code-block:: python
+    
+        ad_hoc_data(
+            training_size=8,
+            test_size=4,
+            n=4,
+            plot_data=False,
+            one_hot=False,
+            labelling_method="measurement",
+            sampling_method="sobol",
+            entanglement="circular"
+        )

--- a/releasenotes/notes/feature-ad_hoc_data_multiqubit-b16eb32337e7959d.yaml
+++ b/releasenotes/notes/feature-ad_hoc_data_multiqubit-b16eb32337e7959d.yaml
@@ -3,7 +3,8 @@ features:
   - |
     The :class:`~qiskit_machine_learning.datasets.ad_hoc_data` class now supports more than
     three qubits. It also now supports multiple sampling methods, linear/circular/full
-    entanglements and also both expectation-based and measurement-based labelling.
+    entanglements and also both expectation-based and measurement-based labelling. Note
+    that the argument "gap" is now a keyword argument and no longer a positional argument.
 
     Example of a 4-qubit dataset with the new features:
 

--- a/test/datasets/test_ad_hoc_data.py
+++ b/test/datasets/test_ad_hoc_data.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2024.
+# (C) Copyright IBM 2020, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -12,10 +12,9 @@
 
 """ Test Ad Hoc Data """
 
-import unittest
-
 from test import QiskitMachineLearningTestCase
 
+import unittest
 import json
 import numpy as np
 from ddt import ddt, unpack, idata
@@ -34,76 +33,454 @@ class TestAdHocData(QiskitMachineLearningTestCase):
     @unpack
     def test_ad_hoc_data(self, num_features):
         """Ad Hoc Data test."""
-
         training_features, training_labels, _, test_labels = ad_hoc_data(
-            training_size=20, test_size=10, n=num_features, gap=0.3, plot_data=False, one_hot=False
+            training_size=20,
+            test_size=10,
+            n=num_features,
+            gap=0.3,
+            plot_data=False,
+            one_hot=False,
         )
         np.testing.assert_array_equal(training_features.shape, (40, num_features))
         np.testing.assert_array_equal(training_labels.shape, (40,))
-        np.testing.assert_array_almost_equal(
-            test_labels, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        )
+        np.testing.assert_array_almost_equal(test_labels, np.array([0] * 10 + [1] * 10))
 
-        _, _, _, test_labels = ad_hoc_data(
-            training_size=20, test_size=10, n=num_features, gap=0.3, plot_data=False, one_hot=True
+        # Now one_hot=True
+        _, _, _, test_labels_oh = ad_hoc_data(
+            training_size=20,
+            test_size=10,
+            n=num_features,
+            gap=0.3,
+            plot_data=False,
+            one_hot=True,
         )
-
-        np.testing.assert_array_equal(test_labels.shape, (20, 2))
-        np.testing.assert_array_equal(
-            test_labels,
-            [
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [1, 0],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-                [0, 1],
-            ],
-        )
-
-    @idata(
-        ([1], [4]),
-    )
-    @unpack
-    def test_wrong_params(self, num_features):
-        """Tests Ad Hoc Data with wrong parameters."""
-        with self.assertRaises(ValueError):
-            _, _, _, _ = ad_hoc_data(training_size=20, test_size=10, n=num_features, gap=0.3)
+        np.testing.assert_array_equal(test_labels_oh.shape, (20, 2))
+        np.testing.assert_array_equal(test_labels_oh, np.array([[1, 0]] * 10 + [[0, 1]] * 10))
 
     def test_ref_data(self):
         """Tests ad hoc against known reference data"""
         input_file = self.get_resource_path("ad_hoc_ref.json", "datasets")
         with open(input_file, encoding="utf8") as file:
             ref_data = json.load(file)
+
         for seed in ref_data:
             algorithm_globals.random_seed = int(seed)
-            training_features, training_labels, test_features, test_labels = ad_hoc_data(
-                training_size=20, test_size=5, n=2, gap=0.3, plot_data=False, one_hot=False
+            (
+                training_features,
+                training_labels,
+                test_features,
+                test_labels,
+            ) = ad_hoc_data(
+                training_size=20,
+                test_size=5,
+                n=2,
+                gap=0.3,
+                plot_data=False,
+                one_hot=False,
             )
             with self.subTest("Test training_features"):
                 np.testing.assert_almost_equal(
-                    ref_data[seed]["training_features"], training_features
+                    ref_data[seed]["training_features"],
+                    training_features,
                 )
             with self.subTest("Test training_labels"):
-                np.testing.assert_almost_equal(ref_data[seed]["training_labels"], training_labels)
+                np.testing.assert_almost_equal(
+                    ref_data[seed]["training_labels"],
+                    training_labels,
+                )
             with self.subTest("Test test_features"):
-                np.testing.assert_almost_equal(ref_data[seed]["test_features"], test_features)
+                np.testing.assert_almost_equal(
+                    ref_data[seed]["test_features"],
+                    test_features,
+                )
             with self.subTest("Test test_labels"):
-                np.testing.assert_almost_equal(ref_data[seed]["test_labels"], test_labels)
+                np.testing.assert_almost_equal(
+                    ref_data[seed]["test_labels"],
+                    test_labels,
+                )
+
+    def test_entanglement_linear(self):
+        """Test linear entanglement."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            entanglement="linear",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_entanglement_circular(self):
+        """Test circular entanglement."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            entanglement="circular",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_entanglement_full(self):
+        """Test full entanglement."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            entanglement="full",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_sampling_grid(self):
+        """Test grid sampling method."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            sampling_method="grid",
+            plot_data=False,
+            one_hot=False,
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_sampling_sobol(self):
+        """Test Sobol sampling method."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            sampling_method="sobol",
+            plot_data=False,
+            one_hot=False,
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_sampling_hypercube(self):
+        """Test hypercube sampling with divisions parameter."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            sampling_method="hypercube",
+            divisions=10,
+            plot_data=False,
+            one_hot=False,
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_labelling_expectation(self):
+        """Test expectation labelling method."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            labelling_method="expectation",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_labelling_measurement(self):
+        """Test measurement labelling method."""
+        (
+            training_features,
+            training_labels,
+            test_features,
+            test_labels,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            labelling_method="measurement",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(training_labels.shape, (20,))
+        self.assertEqual(test_features.shape, (10, 2))
+        self.assertEqual(test_labels.shape, (10,))
+
+    def test_custom_class_labels(self):
+        """Test custom class labels."""
+        custom_labels = ["Class1", "Class2"]
+        (
+            _,
+            training_labels,
+            _,
+            _,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            class_labels=custom_labels,
+        )
+
+        unique_labels = np.unique(training_labels)
+        self.assertEqual(len(unique_labels), 2)
+        for label in custom_labels:
+            self.assertIn(label, unique_labels)
+
+        # Test with one_hot=True
+        (
+            _,
+            training_labels_onehot,
+            _,
+            test_labels_onehot,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=True,
+            class_labels=custom_labels,
+        )
+
+        self.assertEqual(training_labels_onehot.shape, (20, 2))
+        self.assertEqual(test_labels_onehot.shape, (10, 2))
+
+    def test_include_sample_total(self):
+        """Test include_sample_total parameter returns 5-tuple."""
+        result = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            include_sample_total=True,
+        )
+        self.assertEqual(len(result), 5)
+        self.assertIsInstance(result[4], int)
+
+    def test_higher_qubits(self):
+        """Test with dimensions higher than 3 (n=4)."""
+        (
+            training_features,
+            _,
+            test_features,
+            _,
+        ) = ad_hoc_data(
+            training_size=5,
+            test_size=3,
+            n=4,
+            plot_data=False,
+            one_hot=False,
+            sampling_method="sobol",
+        )
+        self.assertEqual(training_features.shape, (10, 4))
+        self.assertEqual(test_features.shape, (6, 4))
+
+    def test_error_cases(self):
+        """Test error cases in the new implementation."""
+
+        # Test negative training_size
+        with self.assertRaises(ValueError):
+            ad_hoc_data(training_size=-1, test_size=5, n=2)
+
+        # Test negative test_size
+        with self.assertRaises(ValueError):
+            ad_hoc_data(training_size=5, test_size=-1, n=2)
+
+        # Test invalid n
+        with self.assertRaises(ValueError):
+            ad_hoc_data(training_size=5, test_size=5, n=0)
+
+        # Test negative gap with expectation labelling
+        with self.assertRaises(ValueError):
+            ad_hoc_data(
+                training_size=5,
+                test_size=5,
+                n=2,
+                gap=-1,
+                labelling_method="expectation",
+            )
+
+        # Test invalid entanglement
+        with self.assertRaises(ValueError):
+            ad_hoc_data(
+                training_size=5,
+                test_size=5,
+                n=2,
+                entanglement="invalid",
+            )
+
+        # Test invalid sampling method
+        with self.assertRaises(ValueError):
+            ad_hoc_data(
+                training_size=5,
+                test_size=5,
+                n=2,
+                sampling_method="invalid",
+            )
+
+        # Test hypercube without divisions
+        with self.assertRaises(ValueError):
+            ad_hoc_data(
+                training_size=5,
+                test_size=5,
+                n=2,
+                sampling_method="hypercube",
+            )
+
+        # Test invalid labelling method
+        with self.assertRaises(ValueError):
+            ad_hoc_data(
+                training_size=5,
+                test_size=5,
+                n=2,
+                labelling_method="invalid",
+            )
+
+        # Test grid sampling with n > 3
+        with self.assertRaises(ValueError):
+            ad_hoc_data(
+                training_size=5,
+                test_size=5,
+                n=4,
+                sampling_method="grid",
+            )
+
+    def test_hypercube_sampling_linear_entanglement(self):
+        """Test hypercube sampling and linear entanglement."""
+        (
+            training_features,
+            _,
+            test_features,
+            _,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            plot_data=False,
+            one_hot=False,
+            sampling_method="hypercube",
+            divisions=12,
+            entanglement="linear",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(test_features.shape, (10, 2))
+
+    def test_custom_labels_circular_entanglement(self):
+        """Test custom labels with circular entanglement."""
+        custom_labels = ["Yes", "No"]
+        (
+            training_features,
+            training_labels,
+            test_features,
+            _,
+        ) = ad_hoc_data(
+            training_size=8,
+            test_size=4,
+            n=3,
+            plot_data=False,
+            one_hot=False,
+            entanglement="circular",
+            class_labels=custom_labels,
+        )
+        self.assertEqual(training_features.shape, (16, 3))
+        self.assertEqual(test_features.shape, (8, 3))
+        unique_labels = np.unique(training_labels)
+        self.assertIn("Yes", unique_labels)
+        self.assertIn("No", unique_labels)
+
+    def test_measurement_sobol_sampling(self):
+        """Test custom labels with circular entanglement."""
+        (
+            training_features,
+            _,
+            test_features,
+            _,
+        ) = ad_hoc_data(
+            training_size=8,
+            test_size=4,
+            n=3,
+            plot_data=False,
+            one_hot=False,
+            labelling_method="measurement",
+            sampling_method="sobol",
+        )
+        self.assertEqual(training_features.shape, (16, 3))
+        self.assertEqual(test_features.shape, (8, 3))
+
+    def test_expectation_labelling_with_gap(self):
+        """Test expectation labelling with a non-zero gap."""
+        (
+            training_features,
+            _,
+            test_features,
+            _,
+        ) = ad_hoc_data(
+            training_size=10,
+            test_size=5,
+            n=2,
+            gap=0.5,
+            plot_data=False,
+            one_hot=False,
+            labelling_method="expectation",
+        )
+        self.assertEqual(training_features.shape, (20, 2))
+        self.assertEqual(test_features.shape, (10, 2))
 
 
 if __name__ == "__main__":

--- a/test/datasets/test_ad_hoc_data.py
+++ b/test/datasets/test_ad_hoc_data.py
@@ -311,7 +311,7 @@ class TestAdHocData(QiskitMachineLearningTestCase):
             include_sample_total=True,
         )
         self.assertEqual(len(result), 5)
-        self.assertIsInstance(result[4], int)
+        np.testing.assert_array_equal(result[4], np.array([30]))
 
     def test_higher_qubits(self):
         """Test with dimensions higher than 3 (n=4)."""


### PR DESCRIPTION
### Summary

My previous pull request became messy due to bad version control from my side. So I've created a new one

This is related to https://github.com/qiskit-community/qiskit-machine-learning/issues/330

I have rewritten the ad_hoc dataset to work for n>3. I have also made some of the operations more efficient.

I'm also working on bringing more dataset generators to the repository, so I hope ad_hoc.py can still be kept around as the simpler one in the family now that it's been rewritten

### Details and comments

1. The tensor products such as H^{(x)n} were written in n step loops, I've made them logn step loops. And similar other small optimizations such as precomputing Zi*Zj. This step also supports 3 types of entangelement now: linear/circular/full

2. The old implementation did an n-dimensional grid for generating random phase vectors. While this brought uniformity with small number of qubits, it was too much computational overhead for larger numbers. I've have added 2 more options of stratified sampling. The old method has been retained as the "grid" method as suggested so that old user codes don't behave differently now. The two other methods included are "hypercube" and "sobol". Docstring has been updated and can be referred to for more information on the methods

3. The old implementation had labelling done with parity() and majority() in n=2 and n=3 respectively. I've used an n-qubit Z matrix directly, which aligns better with the reference paper attached in the documentation and also relieves the constraint an n being 2 or 3.

4. Vectorized the labelling loop. This has given some performance gain. I have also given two options: the same "expectation" based labelling has been retained but also a "measurement" based labelling has been added

5. I've verified lint. @rogue-infinity has developed unittests for this revamped ad hoc dataset. They have been verified to pass