### PR TITLE
Pin Qiskit to `<2` in next release

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,1 @@
-numpy>=2
-qiskit<2.0
+

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 numpy>=2
+qiskit<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-qiskit>=1.0
+qiskit>=1.0,<2.0
+numpy>=2.0
 scipy>=1.4
-numpy>=1.17
 scikit-learn>=1.2
 setuptools>=40.1
 dill>=0.3.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Pinning Qiskit<2 will avoid breaking changes to affect current installations. This potential effect was raised in #897. The constraint can be removed when QML achieves full compatibility with Qiskit 2.


