### PR TITLE
Fix CI for mypy and add explicit shape for COO

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -193,7 +193,7 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
         # training loop
         for step in range(1, self._num_steps + 1):
             # for every step, a random index (determining a random datum) is fixed
-            i = algorithm_globals.random.integers(0, len(y))
+            i = int(algorithm_globals.random.integers(0, len(y)))
 
             value = self._compute_weighted_kernel_sum(i, X, training=True)
 

--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -237,7 +237,7 @@ class _TorchNNFunction(Function):
                     from sparse import COO
 
                     grad_output = grad_output.detach().cpu()
-                    grad_coo = COO(grad_output.indices(), grad_output.values())
+                    grad_coo = COO(grad_output.indices(), grad_output.values(), shape=grad_output.shape)
 
                     # Takes gradients from previous layer in backward pass (i.e. later layer in
                     # forward pass) j for each observation i in the batch. Multiplies this with
@@ -280,7 +280,7 @@ class _TorchNNFunction(Function):
                     from sparse import COO
 
                     grad_output = grad_output.detach().cpu()
-                    grad_coo = COO(grad_output.indices(), grad_output.values())
+                    grad_coo = COO(grad_output.indices(), grad_output.values(), shape=grad_output.shape)
 
                     # Takes gradients from previous layer in backward pass (i.e. later layer in
                     # forward pass) j for each observation i in the batch. Multiplies this with

--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -237,7 +237,9 @@ class _TorchNNFunction(Function):
                     from sparse import COO
 
                     grad_output = grad_output.detach().cpu()
-                    grad_coo = COO(grad_output.indices(), grad_output.values(), shape=grad_output.shape)
+                    grad_coo = COO(
+                        grad_output.indices(), grad_output.values(), shape=grad_output.shape
+                    )
 
                     # Takes gradients from previous layer in backward pass (i.e. later layer in
                     # forward pass) j for each observation i in the batch. Multiplies this with
@@ -280,7 +282,9 @@ class _TorchNNFunction(Function):
                     from sparse import COO
 
                     grad_output = grad_output.detach().cpu()
-                    grad_coo = COO(grad_output.indices(), grad_output.values(), shape=grad_output.shape)
+                    grad_coo = COO(
+                        grad_output.indices(), grad_output.values(), shape=grad_output.shape
+                    )
 
                     # Takes gradients from previous layer in backward pass (i.e. later layer in
                     # forward pass) j for each observation i in the batch. Multiplies this with

--- a/qiskit_machine_learning/neural_networks/effective_dimension.py
+++ b/qiskit_machine_learning/neural_networks/effective_dimension.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,7 @@
 
 import logging
 import time
-from typing import Union, List, Tuple
+from typing import Any, Union, List, Tuple
 
 import numpy as np
 from scipy.special import logsumexp
@@ -136,14 +136,14 @@ class EffectiveDimension:
              outputs: QNN output vector, result of forward passes, of shape
                 ``(num_input_samples * num_weight_samples, output_size)``.
         """
-        grads = np.zeros(
+        grads: Any = np.zeros(
             (
                 self._num_input_samples * self._num_weight_samples,
                 self._model.output_shape[0],
                 self._model.num_weights,
             )
         )
-        outputs = np.zeros(
+        outputs: Any = np.zeros(
             (self._num_input_samples * self._num_weight_samples, self._model.output_shape[0])
         )
 

--- a/qiskit_machine_learning/optimizers/adam_amsgrad.py
+++ b/qiskit_machine_learning/optimizers/adam_amsgrad.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
+# (C) Copyright IBM 2019, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -106,10 +106,10 @@ class ADAM(Optimizer):
 
         # runtime variables
         self._t = 0  # time steps
-        self._m = np.zeros(1)
-        self._v = np.zeros(1)
+        self._m: Any = np.zeros(1)
+        self._v: Any = np.zeros(1)
         if self._amsgrad:
-            self._v_eff = np.zeros(1)
+            self._v_eff: Any = np.zeros(1)
 
         if self._snapshot_dir is not None:
             file_path = os.path.join(self._snapshot_dir, "adam_params.csv")

--- a/qiskit_machine_learning/optimizers/aqgd.py
+++ b/qiskit_machine_learning/optimizers/aqgd.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
+# (C) Copyright IBM 2019, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -161,7 +161,7 @@ class AQGD(Optimizer):
         # Evaluate,
         # reshaping to flatten, as expected by objective function
         if self._max_evals_grouped > 1:
-            batches = [
+            batches: Any = [
                 param_sets_to_eval[i : i + self._max_evals_grouped]
                 for i in range(0, len(param_sets_to_eval), self._max_evals_grouped)
             ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

To fix CI. I tested the changes on a couple of machines 1 with 3.9 the other 3.12 and it seems to pass checks locally.

Fixes #917 

### Details and comments

1. There was a unit test failure around shape. See #917 so I added shape parameter explicitly to COO. This had been noted in a deprecation warning that shape would become required and did so in the lastest sparse which is where things broke. It still works with the earlier sparse versions where its optional.

2. There are several mypy failures as below. These do not show up in 3.9 and my first attempt was to add a type: ignore comment for the incompatible type ones which passed under 3.12 but under 3.9 gave` error: Unused "type: ignore" comment  [unused-ignore]` as it does not fail under the older mypy which is still in use by 3.9. Given the code works, though I guess the newer mypy notes the type differences from what it sees to start with being assigned to what is done to the same variable later I simply added an Any type to the variable which passes mypy now under 3.9 and 3.12 since it allows all (any) types.

For the pegagos_svc failure I cast the return of the algorithm_globals.random.integers call to an int type so as to avoid the later use of it in the get being unable to match appropriately.


```
qiskit_machine_learning/optimizers/aqgd.py:170: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]] | ndarray[tuple[int, ...], dtype[float64]]", variable has type "list[ndarray[tuple[int, ...], dtype[Any]] | ndarray[tuple[int, ...], dtype[float64]]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:187: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:189: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:190: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:216: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:217: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:219: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/optimizers/adam_amsgrad.py:234: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[Any]]", variable has type "ndarray[tuple[int], dtype[float64]]")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:177: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "ndarray[tuple[int, int, int], dtype[float64]]")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:178: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "ndarray[tuple[int, int], dtype[float64]]")  [assignment]
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:198: error: Argument 1 to "_compute_weighted_kernel_sum" of "PegasosQSVC" has incompatible type "signedinteger[_64Bit]"; expected "int"  [arg-type]
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:202: error: Invalid index type "signedinteger[_64Bit]" for "dict[int, int]"; expected type "int"  [index]
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:202: error: No overload variant of "get" of "dict" matches argument types "signedinteger[_64Bit]", "int"  [call-overload]
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:202: note: Possible overload variants:
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:202: note:     def get(self, int, /) -> int
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:202: note:     def get(self, int, int, /) -> int
qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py:202: note:     def [_T] get(self, int, _T, /) -> int | _T
```
