### PR TITLE
Fix for issue #911

### DIFF
--- a/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -92,13 +92,13 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
         )
 
         # override the num of features defined in the base class
-        self._num_features = feature_map.num_parameters - self._num_training_parameters
+        self._num_features = self.feature_map.num_parameters - self._num_training_parameters
         self._feature_parameters = [
             parameter
-            for parameter in feature_map.parameters
+            for parameter in self.feature_map.parameters
             if parameter not in self._training_parameters
         ]
-        self._parameter_dict = {parameter: None for parameter in feature_map.parameters}
+        self._parameter_dict = {parameter: None for parameter in self.feature_map.parameters}
 
     def _get_parameterization(
         self, x_vec: np.ndarray, y_vec: np.ndarray

--- a/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -88,10 +88,10 @@ class TrainableFidelityStatevectorKernel(TrainableKernel, FidelityStatevectorKer
         )
 
         # Override the number of features defined in the base class.
-        self._num_features = feature_map.num_parameters - self._num_training_parameters
+        self._num_features = self.feature_map.num_parameters - self._num_training_parameters
         self._feature_parameters = [
             parameter
-            for parameter in feature_map.parameters
+            for parameter in self.feature_map.parameters
             if parameter not in self._training_parameters
         ]
         self._parameter_dict = {parameter: None for parameter in self.feature_map.parameters}

--- a/releasenotes/notes/fix-trainable-kernel-16e11f1ac80a0b37.yaml
+++ b/releasenotes/notes/fix-trainable-kernel-16e11f1ac80a0b37.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.TrainableFidelityQuantumKernel` and
+    :class:`.TrainableFidelityStatevectorKernel` where not passing a feature map
+    (or explicitly passing None to do the equivalent) would fail internally with
+    a NoneType AttributeError as described by
+    `issue 911 <https://github.com/qiskit-community/qiskit-machine-learning/issues/911>`__.

--- a/test/kernels/test_trainable_fidelity_qkernel.py
+++ b/test/kernels/test_trainable_fidelity_qkernel.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -180,6 +180,24 @@ class TestPrimitivesTrainableQuantumKernelClassify(QiskitMachineLearningTestCase
         )
         self.assertEqual(len(self.training_parameters), kernel.num_training_parameters)
         self.assertEqual(self.num_features, kernel.num_features)
+
+    # Testing changes related to the bug fix for
+    # https://github.com/qiskit-community/qiskit-machine-learning/issues/911
+    @data(TrainableFidelityQuantumKernel, TrainableFidelityStatevectorKernel)
+    def test_default_feature_map(self, trainable_kernel_type):
+        """Test properties of the trainable quantum kernel."""
+        with self.subTest("Do not pass feature map at all"):
+            kernel = trainable_kernel_type()
+            # The above would crash as per the reference issue. This following checks
+            # just make sure feature map is present and built as expected
+            self.assertIsNotNone(kernel.feature_map)
+            self.assertEqual(len(kernel.feature_map.parameters), 2)
+
+        # As above but explicitly pass None
+        with self.subTest("Pass feature map with value None"):
+            kernel = trainable_kernel_type(feature_map=None)
+            self.assertIsNotNone(kernel.feature_map)
+            self.assertEqual(len(kernel.feature_map.parameters), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Internally the subclass of trainable kernel would call its super init where BaseKernel would create a default feature_map, if none was passed, so that the feature_map attribute afterwards was a valid feature_map. Now the derived classes, in places used feature_map instead of self.feature_map where the former was still None. This changes the code to use self.feature_map and added tests to ensure construction is successful.

closes #911

### Details and comments


