### PR TITLE
Constrain qiskit versions in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,7 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   ARGS="-V"
-deps = qiskit>=1.0,<2.0
-       qiskit-aer>=0.11.2
-       -r{toxinidir}/requirements.txt
+deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
        torch
        sparse

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   ARGS="-V"
-deps = git+https://github.com/Qiskit/qiskit.git
-       git+https://github.com/Qiskit/qiskit-aer.git
+deps = qiskit>=1.0,<2.0
+       qiskit-aer>=0.11.2
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
        torch


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This change constrains the Qiskit and Qiskit-Aer versions in `tox.ini` for local testing to reflect the constraints in requirements.


### Details and comments
Fixes https://github.com/qiskit-community/qiskit-machine-learning/issues/912

Note that in local testing, several warnings about primitives deprecations are produced. This is expected as we still support primitives V1 until the hard deprecation with Qiskit 2.0.
