### PR TITLE
Fixes mypy failure with latest mypy 1.16.0

### DIFF
--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
@@ -233,7 +233,9 @@ class LinCombEstimatorGradient(BaseEstimatorGradient):
                     gradient.imag = results[partial_sum_n + n // 2 : partial_sum_n + n]
 
                 else:
-                    gradient = np.real(results[partial_sum_n : partial_sum_n + n])  # type: ignore[assignment, unused-ignore]
+                    gradient = np.real(
+                        results[partial_sum_n : partial_sum_n + n]
+                    )  # type: ignore[assignment, unused-ignore]
                 partial_sum_n += n
                 gradients.append(gradient)
 

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025Added.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
@@ -233,7 +233,7 @@ class LinCombEstimatorGradient(BaseEstimatorGradient):
                     gradient.imag = results[partial_sum_n + n // 2 : partial_sum_n + n]
 
                 else:
-                    gradient = np.real(results[partial_sum_n : partial_sum_n + n])  # type: ignore
+                    gradient = np.real(results[partial_sum_n : partial_sum_n + n])  # type: ignore[assignment, unused-ignore]
                 partial_sum_n += n
                 gradients.append(gradient)
 

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025Added.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -233,7 +233,7 @@ class LinCombEstimatorGradient(BaseEstimatorGradient):
                     gradient.imag = results[partial_sum_n + n // 2 : partial_sum_n + n]
 
                 else:
-                    gradient = np.real(results[partial_sum_n : partial_sum_n + n])
+                    gradient = np.real(results[partial_sum_n : partial_sum_n + n])  # type: ignore
                 partial_sum_n += n
                 gradients.append(gradient)
 

--- a/qiskit_machine_learning/neural_networks/effective_dimension.py
+++ b/qiskit_machine_learning/neural_networks/effective_dimension.py
@@ -70,10 +70,10 @@ class EffectiveDimension:
 
         # Setup things for weight and input samples via setters that deal
         # with the union of types that can be passed so that the private
-        # vars above that have just bee,n set with temp values of right types
+        # vars above that have just been set with temp values of right types
         # to establish typing, get the right values per what was passed.
-        # Note: the samples ones above had been set to None but this results
-        # in errors when checkin using mypy 1.16.0
+        # Note, the samples ones above had been set to None but this results
+        # in errors when checking using mypy 1.16.0
         self.weight_samples = weight_samples
         self.input_samples = input_samples
 

--- a/qiskit_machine_learning/neural_networks/effective_dimension.py
+++ b/qiskit_machine_learning/neural_networks/effective_dimension.py
@@ -62,16 +62,20 @@ class EffectiveDimension:
         """
 
         # Store arguments
-        self._weight_samples = None
-        self._input_samples = None
-        self._num_weight_samples = 1
-        self._num_input_samples = 1
+        self._weight_samples = np.asarray([0.25])
+        self._input_samples = np.asarray([0.5])
+        self._num_weight_samples = len(self._weight_samples)
+        self._num_input_samples = len(self._input_samples)
         self._model = qnn
 
-        # Define weight samples and input samples
-        self.weight_samples = weight_samples  # type: ignore
-        # input setter uses self._model
-        self.input_samples = input_samples  # type: ignore
+        # Setup things for weight and input samples via setters that deal
+        # with the union of types that can be passed so that the private
+        # vars above that have just bee,n set with temp values of right types
+        # to establish typing, get the right values per what was passed.
+        # Note: the samples ones above had been set to None but this results
+        # in errors when checkin using mypy 1.16.0
+        self.weight_samples = weight_samples
+        self.input_samples = input_samples
 
     @property
     def weight_samples(self) -> np.ndarray:

--- a/qiskit_machine_learning/variational_algorithm.py
+++ b/qiskit_machine_learning/variational_algorithm.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
+# (C) Copyright IBM 2019, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -91,7 +91,7 @@ class VariationalResult(AlgorithmResult):
         return self._optimal_value
 
     @optimal_value.setter
-    def optimal_value(self, value: int) -> None:
+    def optimal_value(self, value: float) -> None:
         """Sets optimal value"""
         self._optimal_value = value
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes for latest mypy errors in CI

### Details and comments

Was erroring as follows

```
qiskit_machine_learning/neural_networks/effective_dimension.py:72: error: Unused "type: ignore" comment  [unused-ignore]
qiskit_machine_learning/neural_networks/effective_dimension.py:74: error: Unused "type: ignore" comment  [unused-ignore]
qiskit_machine_learning/neural_networks/effective_dimension.py:86: error: Incompatible types in assignment (expression has type "ndarray[Any, dtype[floating[_64Bit]]]", variable has type "None")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:98: error: Incompatible types in assignment (expression has type "ndarray[Any, dtype[Any]]", variable has type "None")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:112: error: Incompatible types in assignment (expression has type "ndarray[Any, dtype[floating[_64Bit]]]", variable has type "None")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:124: error: Incompatible types in assignment (expression has type "ndarray[Any, dtype[Any]]", variable has type "None")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:150: error: Need type annotation for "param_set"  [var-annotated]
qiskit_machine_learning/neural_networks/effective_dimension.py:334: error: Incompatible types in assignment (expression has type "ndarray[Any, dtype[floating[_64Bit]]]", variable has type "None")  [assignment]
qiskit_machine_learning/neural_networks/effective_dimension.py:349: error: Incompatible types in assignment (expression has type "ndarray[Any, dtype[Any]]", variable has type "None")  [assignment]
qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py:221: error: Incompatible types in assignment (expression has type "Union[Any, float]", variable has type "int")  [assignment]
Found 10 errors in 2 files (checked 188 source files)
```

The last one above, in` quantum_kernel_trainer` I fixed it by correcting the type of a field it was accessing when creating the result where the field in question is part of the results parent class `VariationalResult` in `variational_algorithm`. The `optimal_value` had a type mismatch between the getter and the setter.