### PR TITLE
Specify IO for QSVC

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -105,6 +105,7 @@ datasets
 deepcopy
 denoising
 deriv
+deserialize
 deterministically
 diag
 dicts
@@ -398,6 +399,8 @@ pearson
 pedro
 pegasos
 peruzzo
+picklable
+pkl
 pixelated
 platt
 polyfit
@@ -585,6 +588,7 @@ uncompute
 unitaries
 univariate
 uno
+unpickling
 unscaled
 unsymmetric
 utf

--- a/qiskit_machine_learning/algorithms/classifiers/qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/qsvc.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,9 @@
 """Quantum Support Vector Classifier"""
 
 import warnings
-from typing import Optional
+from typing import Optional, Type
+import pickle
+from pathlib import Path
 
 from sklearn.svm import SVC
 
@@ -51,6 +53,9 @@ class QSVC(SVC, SerializableModelMixin):
                 default to :class:`~qiskit_machine_learning.kernels.FidelityQuantumKernel`.
             *args: Variable length argument list to pass to SVC constructor.
             **kwargs: Arbitrary keyword arguments to pass to SVC constructor.
+
+        Raises:
+            QiskitMachineLearningWarning: If the deprecated 'kernel' kwarg is used.
         """
         if "kernel" in kwargs:
             msg = (
@@ -60,9 +65,11 @@ class QSVC(SVC, SerializableModelMixin):
             warnings.warn(msg, QiskitMachineLearningWarning, stacklevel=2)
             # if we don't delete, then this value clashes with our quantum kernel
             del kwargs["kernel"]
+
         if quantum_kernel is None:
             msg = "No quantum kernel is provided, SamplerV1 based quantum kernel will be used."
             warnings.warn(msg, QiskitMachineLearningWarning, stacklevel=2)
+
         self._quantum_kernel = quantum_kernel if quantum_kernel else FidelityQuantumKernel()
 
         if "random_state" not in kwargs:
@@ -83,7 +90,95 @@ class QSVC(SVC, SerializableModelMixin):
 
     # we override this method to be able to pretty print this instance
     @classmethod
-    def _get_param_names(cls):
+    def _get_param_names(cls) -> list[str]:
+        """
+        Include 'quantum_kernel' in the list of SVC parameters for cloning.
+
+        Returns:
+            list[str]: Sorted list of parameter names.
+        """
         names = SVC._get_param_names()
-        names.remove("kernel")
+        # Remove the base 'kernel' parameter; we override it
+        if "kernel" in names:
+            names.remove("kernel")
         return sorted(names + ["quantum_kernel"])
+
+    def save(self, folder: str, filename: str = "qsvc.pkl") -> None:
+        """
+        Serialize the entire QSVC object to disk, including fitted parameters and
+        the quantum kernel state.
+
+        Args:
+            folder (str): Directory path where the model file will be saved.
+            filename (str): Name of the pickle file (default: 'qsvc.pkl').
+
+        Raises:
+            OSError: If the directory cannot be created.
+            IOError: If the file cannot be written.
+        """
+        folder_path = Path(folder)
+        try:
+            folder_path.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            raise IOError(f"Failed to create directory '{folder}': {error}") from error
+
+        file_path = folder_path / filename
+        try:
+            with file_path.open("wb") as file:
+                pickle.dump(self, file, protocol=pickle.HIGHEST_PROTOCOL)
+        except OSError as error:
+            raise IOError(f"Failed to save QSVC to '{file_path}': {error}") from error
+
+    @classmethod
+    def load(
+        cls: Type["QSVC"],
+        folder: str,
+        filename: str = "qsvc.pkl",
+    ) -> "QSVC":
+        """
+        Deserialize a QSVC object previously saved with `save()`.
+
+        Args:
+            folder (str): Directory path where the model file is located.
+            filename (str): Name of the pickle file (default: 'qsvc.pkl').
+
+        Returns:
+            QSVC: Restored QSVC instance with its quantum kernel.
+
+        Raises:
+            FileNotFoundError: If the specified file does not exist.
+            TypeError: If the loaded object is not a QSVC instance.
+            OSError: For other I/O or unpickling errors.
+        """
+        file_path = Path(folder) / filename
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Model file not found at '{file_path}'.")
+
+        try:
+            with file_path.open("rb") as file:
+                obj = pickle.load(file)
+        except OSError as error:
+            raise IOError(f"Failed to load QSVC from '{file_path}': {error}") from error
+
+        if not isinstance(obj, cls):
+            raise TypeError(f"Loaded object is not a QSVC (got {type(obj).__name__}).")
+
+        return obj
+
+    def __getstate__(self):  # pragma: no cover
+        """
+        Define picklable state for the QSVC instance.
+
+        Returns:
+            dict: A shallow copy of the instance __dict__.
+        """
+        return self.__dict__.copy()
+
+    def __setstate__(self, state):  # pragma: no cover
+        """
+        Restore QSVC state from unpickling.
+
+        Args:
+            state (dict): State dictionary previously returned by __getstate__.
+        """
+        self.__dict__.update(state)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Specifies the `QSVC.save()` and `QSVC.load()` routines by:
-  More robust I/O
- Preserving traceback with explicit exception chaining (`raise … from`).  
- Automatic directory creation using `pathlib.Path.mkdir(..., exist_ok=True)`.  
- Support for an optional `filename` parameter (default: `qsvc.pkl`).

### Details and comments
Fixes #891

