### PR TITLE
Pin scipy to <1.16 and temporary workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 qiskit>=1.0,<2.0
 numpy>=2.0
-scipy>=1.4
+scipy>=1.4,<1.16
 scikit-learn>=1.2
 setuptools>=40.1
 dill>=0.3.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Pins the Scipy dependency to be < 1.16, as a workaround for the failures caused by Scipy 1.16 (#957). PR https://github.com/qiskit-community/qiskit-machine-learning/pull/961 is expected to resolve this compatibility issue and unpin Scipy to the latest stable version once again.

### Suggestion for Qiskit Machine Learning users
As a workaround, please downgrade the Scipy library in your local virtual environments:
```bash
pip install scipy==1.15
```
If this fails, you may try to add the following flags
```bash
pip install --force-reinstall -v "scipy==1.15"
```
To restore Scipy's latest version, you can run `pip install --upgrade scipy`.


