### PR TITLE
Pin scikit-learn for CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ mypy-extensions>=0.4.3
 nbsphinx
 qiskit_sphinx_theme~=1.16.0
 qiskit-ibm-runtime>=0.21
+scikit-learn!=1.7.1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #969 

Disallows the current latest version of scikit-learn, (1.7.1) which has causes a metadata issue in CI when building html under Python 3.13 where it can be installed. See the issue referenced above for more information.

### Details and comments


