### PR TITLE
Update trainable_model.py to assign callback function to non-scipy optimiser

### DIFF
--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -92,7 +92,8 @@ class TrainableModel(SerializableModelMixin):
 
         # call the setter that has some additional checks
         if optimizer is not None and not isinstance(optimizer, SciPyOptimizer):
-            optimizer.callback = callback
+            if hasattr(optimizer, "callback"):
+                optimizer.callback = callback
         self.optimizer = optimizer
 
         self._warm_start = warm_start

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -91,6 +91,8 @@ class TrainableModel(SerializableModelMixin):
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 
         # call the setter that has some additional checks
+        if not isinstance(optimizer, SciPyOptimizer):
+            optimizer.callback=callback
         self.optimizer = optimizer
 
         self._warm_start = warm_start

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -91,8 +91,8 @@ class TrainableModel(SerializableModelMixin):
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 
         # call the setter that has some additional checks
-        if not isinstance(optimizer, SciPyOptimizer):
-            optimizer.callback=callback
+        if optimizer is not None and not isinstance(optimizer, SciPyOptimizer):
+            optimizer.callback = callback
         self.optimizer = optimizer
 
         self._warm_start = warm_start


### PR DESCRIPTION
A simple fix for #893.

With a recent update, we corrected calls for callback functions for SciPy optimisers; however, this prevented calls for non-SciPy optimisers. This way, given callback function can be passed to the optimiser in init.

