### PR TITLE
Change `self._num_features` in ValueError message

### DIFF
--- a/qiskit_machine_learning/kernels/base_kernel.py
+++ b/qiskit_machine_learning/kernels/base_kernel.py
@@ -130,7 +130,7 @@ class BaseKernel(ABC):
                 raise ValueError(
                     f"x_vec and class feature map have incompatible dimensions.\n"
                     f"x_vec has {x_vec.shape[1]} dimensions, "
-                    f"but feature map has {self._feature_map.num_parameters}."
+                    f"but feature map has {self._num_features}."
                 ) from a_e
 
         if y_vec is not None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
For a custom feature map with all parameters marked as trainable, one can run into `self._num_features = 0` (because `feature_map.num_parameters == _num_training_parameters`), which then triggers `_validate_inputs` to detect `x_vec.shape[1] != self._num_features`; however, the ValueError mistakenly reports `self._feature_map.num_parameters` instead of `self._num_features`, making the real problem hard to debug. This update improves the error message to be `self._num_features`. Unittests do not need updating.

### Details and comments

Fixes https://github.com/qiskit-community/qiskit-machine-learning/issues/932

