### PR TITLE
Correct output shape in `EstimatorQNN` tutorial 01

### DIFF
--- a/docs/tutorials/01_neural_networks.ipynb
+++ b/docs/tutorials/01_neural_networks.ipynb
@@ -477,7 +477,9 @@
    "id": "7fba01a3",
    "metadata": {},
    "source": [
-    "For the `EstimatorQNN`, the expected output shape for the forward pass is `(1, num_qubits * num_observables)` where `1` in our case is the number of samples:"
+    "For the `EstimatorQNN`, the forward pass returns an array of shape `(batch_size, num_observables)\n",
+    "`, where `batch_size` is the number of input samples (1 in our case) and `num_observables` is the \n",
+    "length of the observables list."
    ]
   },
   {
@@ -563,7 +565,7 @@
    "id": "3612ff46",
    "metadata": {},
    "source": [
-    "For the `EstimatorQNN`, the expected output shape for the forward pass is `(batch_size, num_qubits * num_observables)`:"
+    "In `EstimatorQNN`, the forward pass returns an array of shape `(batch_size, num_observables)`, where `batch_size` is the number of input samples and `num_observables` is the length of the observables list.:"
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In the tutorial [01_neural_networks](https://qiskit-community.github.io/qiskit-machine-learning/tutorials/01_neural_networks.html), the text reports that the `EstimatorQNN` forward pass produces outputs of shape `(1, num_qubits * num_observables)`. In reality, the forward pass always returns `(batch_size, num_observables)`, i.e., one column per observable, regardless of the number of qubits. This PR updates the tutorial text to correctly describe the output shape as `(batch_size, num_observables)`, where `batch_size` is the number of input samples and `num_observables` is the length of the observables list. Now the documentation matches the behaviour.

### Details and comments
Fixes https://github.com/qiskit-community/qiskit-machine-learning/issues/948

