### PR TITLE
Update run stable tutorials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,8 @@ jobs:
           # clean last sphinx output
           make clean_sphinx
           # get current version
-          version=$(pip show qiskit-machine-learning | awk -F. '/^Version:/ { print substr($1,10), $2-1 }' OFS=.)
+          version=$(pip show qiskit-machine-learning | awk -F. '/^Version:/ {maj=substr($1,10); min=$2;
+          if (min==0){maj=maj-1; min=9}else{min=min-1} print maj "." min}')
           # download stable version
           wget https://codeload.github.com/qiskit-community/qiskit-machine-learning/zip/stable/$version -O /tmp/repo.zip
           unzip /tmp/repo.zip -d /tmp/


### PR DESCRIPTION
This PR fixes  #1017

The “Run stable tutorials” workflow step that downloads stable tutorials from stable/"series".

The previous logic assumed the stable series is always major.(minor-1), which breaks on major bumps when minor == 0.

### What changed

* Updated the stable series resolver so it no longer computes invalid versions like 1.-1 when the project version is 1.0.0.

* The workflow now correctly resolves the prior stable tutorial series (e.g., 1.0.x → stable/0.9) before downloading and copying tutorials.