### PR TITLE
feat: Add regression-based kernel loss functions (SVRLoss, MSRLoss, M…

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -244,6 +244,7 @@ hoyer
 html
 https
 hubbard
+huber
 hyperparameter
 hyperparameters
 hyperplanes

--- a/qiskit_machine_learning/utils/loss_functions/__init__.py
+++ b/qiskit_machine_learning/utils/loss_functions/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -40,6 +40,10 @@ Loss Functions
    L2Loss
    CrossEntropyLoss
    SVCLoss
+   SVRLoss
+   MSRLoss
+   MARLoss
+   HuberLoss
 """
 
 from .loss_functions import (
@@ -49,7 +53,7 @@ from .loss_functions import (
     CrossEntropyLoss,
 )
 
-from .kernel_loss_functions import KernelLoss, SVCLoss
+from .kernel_loss_functions import KernelLoss, SVCLoss, SVRLoss, MSRLoss, MARLoss, HuberLoss
 
 __all__ = [
     "Loss",
@@ -58,4 +62,8 @@ __all__ = [
     "L2Loss",
     "CrossEntropyLoss",
     "SVCLoss",
+    "SVRLoss",
+    "MSRLoss",
+    "MARLoss",
+    "HuberLoss",
 ]

--- a/qiskit_machine_learning/utils/loss_functions/kernel_loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/kernel_loss_functions.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Sequence
 
 import numpy as np
-from sklearn.svm import SVC
+from sklearn.svm import SVC, SVR
 
 # Prevent circular dependencies caused from type checking
 from ...kernels import TrainableKernel
@@ -123,5 +123,201 @@ class SVCLoss(KernelLoss):
 
         # Calculate loss
         loss = np.sum(np.abs(dual_coefs)) - (0.5 * (dual_coefs.T @ kmatrix @ dual_coefs))
+
+        return loss
+
+
+class SVRLoss(KernelLoss):
+    r"""
+    This class provides a kernel loss function for regression tasks by fitting an ``SVR`` model
+    from scikit-learn. Given training samples, :math:`x_{i}`, with labels, :math:`y_{i}`,
+    and a kernel, :math:`K_{θ}`, parameterized by values, :math:`θ`, the loss is defined as:
+
+    .. math::
+
+        SVRLoss = -0.5 \sum_{i,j} \beta_i \beta_j K_θ(x_i, x_j)
+                  - \epsilon \sum_{i} |\beta_i| + \sum_{i} y_i \beta_i
+
+    where :math:`\beta_i = \alpha_i - \alpha_i^*` are the optimal Lagrange multipliers found by
+    solving the standard SVR quadratic program. Note that the hyper-parameters ``C`` and
+    ``epsilon`` can be specified through the keyword args.
+
+    Minimizing this loss over the parameters, :math:`θ`, of the kernel is equivalent to minimizing
+    the optimized dual objective of the SVR, which is a proxy for the primal objective
+    (a combination of the model complexity and the training error).
+
+    See https://arxiv.org/abs/2105.03406 for further details on kernel training (though it focuses
+    on classification, the principle applies to regression).
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Args:
+            **kwargs: Arbitrary keyword arguments to pass to SVR constructor within
+                      SVRLoss evaluation.
+        """
+        self.kwargs = kwargs
+
+    def evaluate(
+        self,
+        parameter_values: Sequence[float],
+        quantum_kernel: TrainableKernel,
+        data: np.ndarray,
+        labels: np.ndarray,
+    ) -> float:
+        # Bind training parameters
+        quantum_kernel.assign_training_parameters(parameter_values)
+
+        # Get estimated kernel matrix
+        kmatrix = quantum_kernel.evaluate(np.array(data))
+
+        # Train a quantum support vector regressor
+        svr = SVR(kernel="precomputed", **self.kwargs)
+        svr.fit(kmatrix, labels)
+
+        # Get dual coefficients (alpha_i - alpha_i^*)
+        dual_coefs = svr.dual_coef_[0]
+
+        # Get support vectors
+        support_vecs = svr.support_
+
+        # Get epsilon
+        epsilon = svr.epsilon
+
+        # Prune kernel matrix of non-support-vector entries
+        kmatrix_support = kmatrix[support_vecs, :][:, support_vecs]
+
+        # Calculate loss (dual objective)
+        # L = -0.5 * beta^T * K * beta - epsilon * sum|beta| + y^T * beta
+        loss = (
+            -0.5 * (dual_coefs.T @ kmatrix_support @ dual_coefs)
+            - epsilon * np.sum(np.abs(dual_coefs))
+            + (labels[support_vecs].T @ dual_coefs)
+        )
+
+        return loss
+
+
+class MSRLoss(KernelLoss):
+    """
+    This class provides a simple mean squared regression loss function by fitting an ``SVR`` model
+    from scikit-learn and computing the mean squared error on the training set.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Args:
+            **kwargs: Arbitrary keyword arguments to pass to SVR constructor within
+                      MSRLoss evaluation.
+        """
+        self.kwargs = kwargs
+
+    def evaluate(
+        self,
+        parameter_values: Sequence[float],
+        quantum_kernel: TrainableKernel,
+        data: np.ndarray,
+        labels: np.ndarray,
+    ) -> float:
+        # Bind training parameters
+        quantum_kernel.assign_training_parameters(parameter_values)
+
+        # Get estimated kernel matrix
+        kmatrix = quantum_kernel.evaluate(np.array(data))
+
+        # Train a quantum support vector regressor
+        svr = SVR(kernel="precomputed", **self.kwargs)
+        svr.fit(kmatrix, labels)
+
+        # Predict on training data
+        predictions = svr.predict(kmatrix)
+
+        # Calculate mean squared error
+        loss = np.mean(np.square(predictions - labels))
+
+        return loss
+
+
+class MARLoss(KernelLoss):
+    """
+    This class provides a mean absolute regression loss function by fitting an ``SVR`` model
+    from scikit-learn and computing the mean absolute error on the training set.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Args:
+            **kwargs: Arbitrary keyword arguments to pass to SVR constructor within
+                      MARLoss evaluation.
+        """
+        self.kwargs = kwargs
+
+    def evaluate(
+        self,
+        parameter_values: Sequence[float],
+        quantum_kernel: TrainableKernel,
+        data: np.ndarray,
+        labels: np.ndarray,
+    ) -> float:
+        # Bind training parameters
+        quantum_kernel.assign_training_parameters(parameter_values)
+
+        # Get estimated kernel matrix
+        kmatrix = quantum_kernel.evaluate(np.array(data))
+
+        # Train a quantum support vector regressor
+        svr = SVR(kernel="precomputed", **self.kwargs)
+        svr.fit(kmatrix, labels)
+
+        # Predict on training data
+        predictions = svr.predict(kmatrix)
+
+        # Calculate mean absolute error
+        loss = np.mean(np.abs(predictions - labels))
+
+        return loss
+
+
+class HuberLoss(KernelLoss):
+    """
+    This class provides a Huber loss function for regression. It is robust to outliers by
+    using a combination of squared error for small errors and absolute error for large errors.
+    """
+
+    def __init__(self, delta: float = 1.0, **kwargs):
+        """
+        Args:
+            delta: The threshold at which to change from squared to linear loss.
+            **kwargs: Arbitrary keyword arguments to pass to SVR constructor.
+        """
+        self.delta = delta
+        self.kwargs = kwargs
+
+    def evaluate(
+        self,
+        parameter_values: Sequence[float],
+        quantum_kernel: TrainableKernel,
+        data: np.ndarray,
+        labels: np.ndarray,
+    ) -> float:
+        # Bind training parameters
+        quantum_kernel.assign_training_parameters(parameter_values)
+
+        # Get estimated kernel matrix
+        kmatrix = quantum_kernel.evaluate(np.array(data))
+
+        # Train a quantum support vector regressor
+        svr = SVR(kernel="precomputed", **self.kwargs)
+        svr.fit(kmatrix, labels)
+
+        # Predict on training data
+        predictions = svr.predict(kmatrix)
+
+        # Calculate Huber loss
+        error = predictions - labels
+        abs_error = np.abs(error)
+        quadratic = np.minimum(abs_error, self.delta)
+        linear = abs_error - quadratic
+        loss = np.mean(0.5 * quadratic**2 + self.delta * linear)
 
         return loss

--- a/releasenotes/notes/0.9/add-regression-kernel-loss-functions-960.yaml
+++ b/releasenotes/notes/0.9/add-regression-kernel-loss-functions-960.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    Added regression-based kernel loss functions for use with
+    :class:`~qiskit_machine_learning.kernels.algorithms.QuantumKernelTrainer`.
+    The following new loss functions are now available:
+
+    * :class:`~qiskit_machine_learning.utils.loss_functions.SVRLoss` -
+      Dual objective-based loss for Support Vector Regression.
+    * :class:`~qiskit_machine_learning.utils.loss_functions.MSRLoss` -
+      Mean squared error loss.
+    * :class:`~qiskit_machine_learning.utils.loss_functions.MARLoss` -
+      Mean absolute error loss.
+    * :class:`~qiskit_machine_learning.utils.loss_functions.HuberLoss` -
+      Robust loss combining squared and absolute error.
+
+    These enable training quantum kernels for regression tasks with algorithms
+    like :class:`~qiskit_machine_learning.algorithms.regressors.QSVR`.
+    Closes `#960 <https://github.com/qiskit-community/qiskit-machine-learning/issues/960>`_.

--- a/test/utils/loss_functions/test_regression_kernel_loss.py
+++ b/test/utils/loss_functions/test_regression_kernel_loss.py
@@ -1,0 +1,83 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2021, 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Regression Kernel Loss Functions"""
+
+import unittest
+from functools import partial
+from test import QiskitMachineLearningTestCase
+from ddt import ddt, data
+import numpy as np
+from scipy.optimize import minimize
+
+from qiskit.circuit.library import zz_feature_map
+from qiskit_machine_learning.utils import algorithm_globals
+from qiskit_machine_learning.kernels import TrainableFidelityQuantumKernel
+from qiskit_machine_learning.kernels.algorithms import QuantumKernelTrainer
+from qiskit_machine_learning.utils.loss_functions import SVRLoss, MSRLoss, MARLoss, HuberLoss
+from qiskit_machine_learning.algorithms.regressors import QSVR
+
+
+@ddt
+class TestRegressionKernelLoss(QiskitMachineLearningTestCase):
+    """Test Regression Kernel Loss Functions Algorithm"""
+
+    def setUp(self):
+        super().setUp()
+        algorithm_globals.random_seed = 10598
+        data_block = zz_feature_map(2)
+        trainable_block = zz_feature_map(2, parameter_prefix="θ")
+        self.training_parameters = trainable_block.parameters
+
+        self.feature_map = data_block.compose(trainable_block).compose(data_block)
+
+        self.sample_train = np.asarray(
+            [
+                [3.07876080, 1.75929189],
+                [6.03185789, 5.27787566],
+                [6.22035345, 2.70176968],
+                [0.18849556, 2.82743339],
+            ]
+        )
+        # Simple linear targets for testing
+        self.label_train = np.sum(self.sample_train, axis=1)
+
+        self.sample_test = np.asarray([[2.199114860, 5.15221195], [0.50265482, 0.06283185]])
+        self.label_test = np.sum(self.sample_test, axis=1)
+
+    @data(SVRLoss, MSRLoss, MARLoss, HuberLoss)
+    def test_regression_loss_fit(self, loss_type):
+        """Test trainer with regression loss functions."""
+        quantum_kernel = TrainableFidelityQuantumKernel(
+            feature_map=self.feature_map,
+            training_parameters=self.training_parameters,
+        )
+        loss = loss_type()
+        optimizer = partial(minimize, method="COBYLA", options={"maxiter": 10})
+        qkt = QuantumKernelTrainer(quantum_kernel=quantum_kernel, loss=loss, optimizer=optimizer)
+        qkt_result = qkt.fit(self.sample_train, self.label_train)
+
+        # Ensure user parameters are bound to real values
+        self.assertTrue(np.all(qkt_result.quantum_kernel.parameter_values))
+
+        # Ensure it works with QSVR
+        qsvr = QSVR(quantum_kernel=qkt_result.quantum_kernel)
+        qsvr.fit(self.sample_train, self.label_train)
+        score = qsvr.score(self.sample_test, self.label_test)
+
+        # We don't necessarily expect a high score with only 10 iterations,
+        # but we expect it to be a finite number.
+        self.assertTrue(np.isfinite(score))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Add regression-based kernel loss functions

## Summary
This PR adds regression-based `KernelLoss` implementations to allow `QuantumKernelTrainer` to be used with regression algorithms like `QSVR`.

**Closes #960**

## Changes
- Added `SVRLoss`: Dual objective-based loss for Support Vector Regression
- Added `MSRLoss`: Mean squared error loss  
- Added `MARLoss`: Mean absolute error loss
- Added `HuberLoss`: Robust loss combining MSE and MAE (with configurable `delta`)

## Files Changed
- `qiskit_machine_learning/utils/loss_functions/kernel_loss_functions.py`
- `qiskit_machine_learning/utils/loss_functions/__init__.py`
- `test/utils/loss_functions/test_regression_kernel_loss.py` (new)
- `releasenotes/notes/0.9/add-regression-kernel-loss-functions-960.yaml` (new)

## Testing
- Added unit tests for all four loss functions
- All existing tests pass without regressions
