### PR TITLE
feat: Add string aliases for regression loss functions

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -348,6 +348,7 @@ mosca
 mpl
 mprev
 msg
+msr
 multiclass
 multinomial
 multioutput

--- a/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
+++ b/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,7 +21,14 @@ import numpy as np
 from ...optimizers import Optimizer, SPSA, Minimizer
 from ...utils import algorithm_globals
 from ...variational_algorithm import VariationalResult
-from ...utils.loss_functions import KernelLoss, SVCLoss
+from ...utils.loss_functions import (
+    KernelLoss,
+    SVCLoss,
+    SVRLoss,
+    MSRLoss,
+    MARLoss,
+    HuberLoss,
+)
 from ...kernels import TrainableKernel
 
 
@@ -97,10 +104,11 @@ class QuantumKernelTrainer:
             quantum_kernel: a trainable quantum kernel to be trained. The
                 :attr:`~.TrainableKernel.parameter_values` will be modified in place after the training.
             loss: A loss function available via string is "svc_loss" which is the same as
-                :class:`~qiskit_machine_learning.utils.loss_functions.SVCLoss`. If a string is
-                passed as the loss function, then the underlying
-                :class:`~qiskit_machine_learning.utils.loss_functions.SVCLoss` object will exhibit
-                default behavior.
+                :class:`~qiskit_machine_learning.utils.loss_functions.SVCLoss`. Other available
+                options are "svr_loss", "msr_loss", "mar_loss", and "huber_loss", corresponding to
+                their respective classes in :mod:`~qiskit_machine_learning.utils.loss_functions`.
+                If a string is passed as the loss function, then the underlying loss object will
+                exhibit default behavior.
             optimizer: An instance of :class:`~qiskit_machine_learning.optimizers.Optimizer` or a
                 callable to be used in training. Refer to
                 :class:`~qiskit_machine_learning.optimizers.Minimizer` for more information on the
@@ -241,9 +249,17 @@ class QuantumKernelTrainer:
 
     def _str_to_loss(self, loss_str: str) -> KernelLoss:
         """Function which maps strings to default KernelLoss objects."""
-        if loss_str == "svc_loss":
-            loss_obj = SVCLoss()
-        else:
-            raise ValueError(f"Unknown loss {loss_str}!")
+        string_to_loss_map = {
+            "svc_loss": SVCLoss,
+            "svr_loss": SVRLoss,
+            "msr_loss": MSRLoss,
+            "mar_loss": MARLoss,
+            "huber_loss": HuberLoss,
+        }
+        try:
+            loss_class = string_to_loss_map[loss_str]
+            loss_obj = loss_class()
+        except KeyError as unknown_loss:
+            raise ValueError(f"Unknown loss {unknown_loss}!") from unknown_loss
 
         return loss_obj

--- a/releasenotes/notes/0.9/add-regression-kernel-loss-functions-960.yaml
+++ b/releasenotes/notes/0.9/add-regression-kernel-loss-functions-960.yaml
@@ -16,4 +16,24 @@ features:
 
     These enable training quantum kernels for regression tasks with algorithms
     like :class:`~qiskit_machine_learning.algorithms.regressors.QSVR`.
+
+    Example usage:
+
+    .. code-block:: python
+
+        from qiskit_machine_learning.kernels import TrainableFidelityQuantumKernel
+        from qiskit_machine_learning.kernels.algorithms import QuantumKernelTrainer
+        from qiskit_machine_learning.utils.loss_functions import SVRLoss
+        from qiskit.circuit.library import ZZFeatureMap
+
+        feature_map = ZZFeatureMap(2)
+        kernel = TrainableFidelityQuantumKernel(
+            feature_map=feature_map,
+            training_parameters=feature_map.parameters
+        )
+        # Use SVRLoss for regression
+        loss = SVRLoss(C=1.0, epsilon=0.1)
+        trainer = QuantumKernelTrainer(quantum_kernel=kernel, loss=loss)
+        # result = trainer.fit(X_train, y_train)
+
     Closes `#960 <https://github.com/qiskit-community/qiskit-machine-learning/issues/960>`_.

--- a/test/utils/loss_functions/test_regression_kernel_loss.py
+++ b/test/utils/loss_functions/test_regression_kernel_loss.py
@@ -78,6 +78,22 @@ class TestRegressionKernelLoss(QiskitMachineLearningTestCase):
         # but we expect it to be a finite number.
         self.assertTrue(np.isfinite(score))
 
+    @data(
+        ("svr_loss", SVRLoss),
+        ("msr_loss", MSRLoss),
+        ("mar_loss", MARLoss),
+        ("huber_loss", HuberLoss),
+    )
+    def test_loss_strings(self, config):
+        """Test trainer with regression loss function strings."""
+        loss_str, loss_cls = config
+        quantum_kernel = TrainableFidelityQuantumKernel(
+            feature_map=self.feature_map,
+            training_parameters=self.training_parameters,
+        )
+        qkt = QuantumKernelTrainer(quantum_kernel=quantum_kernel, loss=loss_str)
+        self.assertIsInstance(qkt.loss, loss_cls)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Updates QuantumKernelTrainer to support string aliases ('svr_loss', 'msr_loss', 'mar_loss', 'huber_loss') for the newly added regression loss functions. (Merged in #1021 for #960 )
- updates release notes with usage examples (As Discussed at #1021 )
- adds unit tests for the string aliases
