### PR TITLE
Fix mypy/lint issues in various files

### DIFF
--- a/qiskit_machine_learning/datasets/entanglement_concentration.py
+++ b/qiskit_machine_learning/datasets/entanglement_concentration.py
@@ -41,10 +41,18 @@ def entanglement_concentration_data(
     class_labels: list | None = None,
     formatting: str = "ndarray",
 ) -> (
-    tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    | tuple[list[Statevector], np.ndarray, list[Statevector], np.ndarray]
-    | tuple[list[Statevector], np.ndarray, list[Statevector], np.ndarray, np.ndarray]
+    # tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    # | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+    # | tuple[list[Statevector], np.ndarray, list[Statevector], np.ndarray]
+    # | tuple[list[Statevector], np.ndarray, list[Statevector], np.ndarray, np.ndarray]
+    tuple[np.ndarray | list[Statevector], np.ndarray, np.ndarray | list[Statevector], np.ndarray]
+    | tuple[
+        np.ndarray | list[Statevector],
+        np.ndarray,
+        np.ndarray | list[Statevector],
+        np.ndarray,
+        np.ndarray,
+    ]
 ):
     r"""
     Generates a dataset that comprises Quantum States with two different
@@ -201,6 +209,9 @@ def entanglement_concentration_data(
 
     a_features = u_low @ psi_in
     b_features = u_high @ psi_in
+
+    x_train: np.ndarray | list[Statevector]
+    x_test: np.ndarray | list[Statevector]
 
     if formatting == "ndarray":
         x_train = np.concatenate((a_features[:training_size], b_features[:training_size]), axis=0)

--- a/qiskit_machine_learning/datasets/entanglement_concentration.py
+++ b/qiskit_machine_learning/datasets/entanglement_concentration.py
@@ -41,10 +41,6 @@ def entanglement_concentration_data(
     class_labels: list | None = None,
     formatting: str = "ndarray",
 ) -> (
-    # tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    # | tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-    # | tuple[list[Statevector], np.ndarray, list[Statevector], np.ndarray]
-    # | tuple[list[Statevector], np.ndarray, list[Statevector], np.ndarray, np.ndarray]
     tuple[np.ndarray | list[Statevector], np.ndarray, np.ndarray | list[Statevector], np.ndarray]
     | tuple[
         np.ndarray | list[Statevector],

--- a/qiskit_machine_learning/gradients/base/base_qgt.py
+++ b/qiskit_machine_learning/gradients/base/base_qgt.py
@@ -274,8 +274,10 @@ class BaseQGT(ABC):
             g_parameter_indices_d = {param: i for i, param in enumerate(g_parameter_indices)}
             rows, cols = np.triu_indices(len(parameters_))
             for row, col in zip(rows, cols):
-                for g_parameter1, coeff1 in gradient_circuit.parameter_map[parameters_[row]]:
-                    for g_parameter2, coeff2 in gradient_circuit.parameter_map[parameters_[col]]:
+                for g_parameter1, coeff1 in gradient_circuit.parameter_map[parameters_[int(row)]]:
+                    for g_parameter2, coeff2 in gradient_circuit.parameter_map[
+                        parameters_[int(col)]
+                    ]:
                         if isinstance(coeff1, ParameterExpression):
                             local_map = {
                                 p: parameter_values_[circuit.parameters.data.index(p)]

--- a/qiskit_machine_learning/gradients/base/base_qgt.py
+++ b/qiskit_machine_learning/gradients/base/base_qgt.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
+# (C) Copyright IBM 2022, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -36,7 +36,6 @@ class TestReadmeSample(QiskitMachineLearningTestCase):
         readme_path = Path(__file__).parent.parent.joinpath(readme_name)
         if not readme_path.exists() or not readme_path.is_file():
             self.fail(msg=f"{readme_name} not found at {readme_path}")
-            return
 
         # gets the first matched code sample
         # assumes one code sample to test per readme
@@ -53,14 +52,12 @@ class TestReadmeSample(QiskitMachineLearningTestCase):
 
         if readme_sample is None:
             self.skipTest(f"No sample found inside {readme_name}.")
-            return
 
         with contextlib.redirect_stdout(io.StringIO()) as out:
             try:
                 exec(readme_sample)
             except Exception as ex:  # pylint: disable=broad-except
                 self.fail(str(ex))
-                return
 
         score = None
         str_ref = "Testing accuracy: "
@@ -73,7 +70,6 @@ class TestReadmeSample(QiskitMachineLearningTestCase):
 
         if score is None:
             self.fail(f"Failed to find final score inside {readme_name}.")
-            return
 
         self.assertGreater(score, 0.7)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes mypy and lint errors across multiple files and tests

### Details and comments

- In entanglement_concentration.py x_train and x_test can be both list[statevector] and np.ndarray. This was causing mypy errors and has been fixed by defining the variables as a union of the datatypes.
- In base_qpt.py row and col were causing mypy errors when indexing parameters_. This was fixed by explicitly converting them to python integers.
- test_readme_sample.py had unreachable code since the .fail and .skiptest methods exit the code and therefore the returns are unnecessary. These have now been removed.