### PR TITLE
Add UKRI-STFC (Hartree Centre) copyright checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/lowercase_filter.py
+++ b/docs/lowercase_filter.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/lowercase_filter.py
+++ b/docs/lowercase_filter.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/tutorials/tutorial_magics.py
+++ b/docs/tutorials/tutorial_magics.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project
 #
-# (C) Copyright IBM 2017, 2024
+# (C) Copyright IBM 2017, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/tutorials/tutorial_magics.py
+++ b/docs/tutorials/tutorial_magics.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project
 #
-# (C) Copyright IBM 2017, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2017, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/__init__.py
+++ b/qiskit_machine_learning/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/__init__.py
+++ b/qiskit_machine_learning/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithm_job.py
+++ b/qiskit_machine_learning/algorithm_job.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithm_result.py
+++ b/qiskit_machine_learning/algorithm_result.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithm_result.py
+++ b/qiskit_machine_learning/algorithm_result.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/__init__.py
+++ b/qiskit_machine_learning/algorithms/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/__init__.py
+++ b/qiskit_machine_learning/algorithms/classifiers/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/__init__.py
+++ b/qiskit_machine_learning/algorithms/classifiers/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
+++ b/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
+++ b/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/qsvc.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/qsvc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/inference/__init__.py
+++ b/qiskit_machine_learning/algorithms/inference/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/inference/qbayesian.py
+++ b/qiskit_machine_learning/algorithms/inference/qbayesian.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/inference/qbayesian.py
+++ b/qiskit_machine_learning/algorithms/inference/qbayesian.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/objective_functions.py
+++ b/qiskit_machine_learning/algorithms/objective_functions.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/objective_functions.py
+++ b/qiskit_machine_learning/algorithms/objective_functions.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/__init__.py
+++ b/qiskit_machine_learning/algorithms/regressors/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/__init__.py
+++ b/qiskit_machine_learning/algorithms/regressors/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
+++ b/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
+++ b/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/qsvr.py
+++ b/qiskit_machine_learning/algorithms/regressors/qsvr.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/qsvr.py
+++ b/qiskit_machine_learning/algorithms/regressors/qsvr.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/regressors/vqr.py
+++ b/qiskit_machine_learning/algorithms/regressors/vqr.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/serializable_model.py
+++ b/qiskit_machine_learning/algorithms/serializable_model.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/serializable_model.py
+++ b/qiskit_machine_learning/algorithms/serializable_model.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/circuit/library/__init__.py
+++ b/qiskit_machine_learning/circuit/library/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/circuit/library/__init__.py
+++ b/qiskit_machine_learning/circuit/library/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/circuit/library/qnn_circuit.py
+++ b/qiskit_machine_learning/circuit/library/qnn_circuit.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/circuit/library/raw_feature_vector.py
+++ b/qiskit_machine_learning/circuit/library/raw_feature_vector.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/circuit/library/raw_feature_vector.py
+++ b/qiskit_machine_learning/circuit/library/raw_feature_vector.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025
+# (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/connectors/__init__.py
+++ b/qiskit_machine_learning/connectors/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/datasets/__init__.py
+++ b/qiskit_machine_learning/datasets/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/datasets/__init__.py
+++ b/qiskit_machine_learning/datasets/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/datasets/entanglement_concentration.py
+++ b/qiskit_machine_learning/datasets/entanglement_concentration.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/exceptions.py
+++ b/qiskit_machine_learning/exceptions.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/exceptions.py
+++ b/qiskit_machine_learning/exceptions.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/__init__.py
+++ b/qiskit_machine_learning/gradients/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/__init__.py
+++ b/qiskit_machine_learning/gradients/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/__init__.py
+++ b/qiskit_machine_learning/gradients/base/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/__init__.py
+++ b/qiskit_machine_learning/gradients/base/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/base_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/base/base_estimator_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/base_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/base/base_estimator_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/base_qgt.py
+++ b/qiskit_machine_learning/gradients/base/base_qgt.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/base_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/base/base_sampler_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/base_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/base/base_sampler_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/estimator_gradient_result.py
+++ b/qiskit_machine_learning/gradients/base/estimator_gradient_result.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/estimator_gradient_result.py
+++ b/qiskit_machine_learning/gradients/base/estimator_gradient_result.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/qgt_result.py
+++ b/qiskit_machine_learning/gradients/base/qgt_result.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/qgt_result.py
+++ b/qiskit_machine_learning/gradients/base/qgt_result.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/sampler_gradient_result.py
+++ b/qiskit_machine_learning/gradients/base/sampler_gradient_result.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/base/sampler_gradient_result.py
+++ b/qiskit_machine_learning/gradients/base/sampler_gradient_result.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/__init__.py
+++ b/qiskit_machine_learning/gradients/lin_comb/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/__init__.py
+++ b/qiskit_machine_learning/gradients/lin_comb/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_estimator_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_qgt.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_qgt.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_qgt.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_qgt.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_sampler_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/lin_comb/lin_comb_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/lin_comb/lin_comb_sampler_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/param_shift/__init__.py
+++ b/qiskit_machine_learning/gradients/param_shift/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/param_shift/__init__.py
+++ b/qiskit_machine_learning/gradients/param_shift/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/param_shift/param_shift_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/param_shift/param_shift_estimator_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/param_shift/param_shift_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/param_shift/param_shift_estimator_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/param_shift/param_shift_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/param_shift/param_shift_sampler_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/param_shift/param_shift_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/param_shift/param_shift_sampler_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/qfi.py
+++ b/qiskit_machine_learning/gradients/qfi.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/qfi.py
+++ b/qiskit_machine_learning/gradients/qfi.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/qfi_result.py
+++ b/qiskit_machine_learning/gradients/qfi_result.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/qfi_result.py
+++ b/qiskit_machine_learning/gradients/qfi_result.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/spsa/__init__.py
+++ b/qiskit_machine_learning/gradients/spsa/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/spsa/__init__.py
+++ b/qiskit_machine_learning/gradients/spsa/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/spsa/spsa_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/spsa/spsa_estimator_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/spsa/spsa_estimator_gradient.py
+++ b/qiskit_machine_learning/gradients/spsa/spsa_estimator_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/spsa/spsa_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/spsa/spsa_sampler_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/spsa/spsa_sampler_gradient.py
+++ b/qiskit_machine_learning/gradients/spsa/spsa_sampler_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/utils.py
+++ b/qiskit_machine_learning/gradients/utils.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/gradients/utils.py
+++ b/qiskit_machine_learning/gradients/utils.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
+++ b/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/base_kernel.py
+++ b/qiskit_machine_learning/kernels/base_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/base_kernel.py
+++ b/qiskit_machine_learning/kernels/base_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/trainable_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/trainable_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/__init__.py
+++ b/qiskit_machine_learning/neural_networks/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/__init__.py
+++ b/qiskit_machine_learning/neural_networks/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/effective_dimension.py
+++ b/qiskit_machine_learning/neural_networks/effective_dimension.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/estimator_qnn.py
+++ b/qiskit_machine_learning/neural_networks/estimator_qnn.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/estimator_qnn.py
+++ b/qiskit_machine_learning/neural_networks/estimator_qnn.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/sampler_qnn.py
+++ b/qiskit_machine_learning/neural_networks/sampler_qnn.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/sampler_qnn.py
+++ b/qiskit_machine_learning/neural_networks/sampler_qnn.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/__init__.py
+++ b/qiskit_machine_learning/optimizers/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/__init__.py
+++ b/qiskit_machine_learning/optimizers/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/adam_amsgrad.py
+++ b/qiskit_machine_learning/optimizers/adam_amsgrad.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/aqgd.py
+++ b/qiskit_machine_learning/optimizers/aqgd.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/aqgd.py
+++ b/qiskit_machine_learning/optimizers/aqgd.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/cg.py
+++ b/qiskit_machine_learning/optimizers/cg.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/cg.py
+++ b/qiskit_machine_learning/optimizers/cg.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/cobyla.py
+++ b/qiskit_machine_learning/optimizers/cobyla.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/cobyla.py
+++ b/qiskit_machine_learning/optimizers/cobyla.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/gradient_descent.py
+++ b/qiskit_machine_learning/optimizers/gradient_descent.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/gsls.py
+++ b/qiskit_machine_learning/optimizers/gsls.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/gsls.py
+++ b/qiskit_machine_learning/optimizers/gsls.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/l_bfgs_b.py
+++ b/qiskit_machine_learning/optimizers/l_bfgs_b.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/l_bfgs_b.py
+++ b/qiskit_machine_learning/optimizers/l_bfgs_b.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nelder_mead.py
+++ b/qiskit_machine_learning/optimizers/nelder_mead.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nft.py
+++ b/qiskit_machine_learning/optimizers/nft.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/__init__.py
+++ b/qiskit_machine_learning/optimizers/nlopts/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/__init__.py
+++ b/qiskit_machine_learning/optimizers/nlopts/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/crs.py
+++ b/qiskit_machine_learning/optimizers/nlopts/crs.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/crs.py
+++ b/qiskit_machine_learning/optimizers/nlopts/crs.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/direct_l.py
+++ b/qiskit_machine_learning/optimizers/nlopts/direct_l.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/direct_l.py
+++ b/qiskit_machine_learning/optimizers/nlopts/direct_l.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/direct_l_rand.py
+++ b/qiskit_machine_learning/optimizers/nlopts/direct_l_rand.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/direct_l_rand.py
+++ b/qiskit_machine_learning/optimizers/nlopts/direct_l_rand.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/esch.py
+++ b/qiskit_machine_learning/optimizers/nlopts/esch.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/esch.py
+++ b/qiskit_machine_learning/optimizers/nlopts/esch.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/isres.py
+++ b/qiskit_machine_learning/optimizers/nlopts/isres.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/isres.py
+++ b/qiskit_machine_learning/optimizers/nlopts/isres.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/nloptimizer.py
+++ b/qiskit_machine_learning/optimizers/nlopts/nloptimizer.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/sbplx.py
+++ b/qiskit_machine_learning/optimizers/nlopts/sbplx.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/nlopts/sbplx.py
+++ b/qiskit_machine_learning/optimizers/nlopts/sbplx.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/optimizer.py
+++ b/qiskit_machine_learning/optimizers/optimizer.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/optimizer.py
+++ b/qiskit_machine_learning/optimizers/optimizer.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/optimizer_utils/__init__.py
+++ b/qiskit_machine_learning/optimizers/optimizer_utils/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/optimizer_utils/__init__.py
+++ b/qiskit_machine_learning/optimizers/optimizer_utils/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/optimizer_utils/learning_rate.py
+++ b/qiskit_machine_learning/optimizers/optimizer_utils/learning_rate.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/p_bfgs.py
+++ b/qiskit_machine_learning/optimizers/p_bfgs.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/powell.py
+++ b/qiskit_machine_learning/optimizers/powell.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/qnspsa.py
+++ b/qiskit_machine_learning/optimizers/qnspsa.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/qnspsa.py
+++ b/qiskit_machine_learning/optimizers/qnspsa.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/scipy_optimizer.py
+++ b/qiskit_machine_learning/optimizers/scipy_optimizer.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/slsqp.py
+++ b/qiskit_machine_learning/optimizers/slsqp.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/spsa.py
+++ b/qiskit_machine_learning/optimizers/spsa.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/steppable_optimizer.py
+++ b/qiskit_machine_learning/optimizers/steppable_optimizer.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/tnc.py
+++ b/qiskit_machine_learning/optimizers/tnc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/umda.py
+++ b/qiskit_machine_learning/optimizers/umda.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optimizers/umda.py
+++ b/qiskit_machine_learning/optimizers/umda.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/optionals.py
+++ b/qiskit_machine_learning/optionals.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/primitives/__init__.py
+++ b/qiskit_machine_learning/primitives/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/primitives/__init__.py
+++ b/qiskit_machine_learning/primitives/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/primitives/estimator.py
+++ b/qiskit_machine_learning/primitives/estimator.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/primitives/estimator.py
+++ b/qiskit_machine_learning/primitives/estimator.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/primitives/sampler.py
+++ b/qiskit_machine_learning/primitives/sampler.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/__init__.py
+++ b/qiskit_machine_learning/state_fidelities/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/__init__.py
+++ b/qiskit_machine_learning/state_fidelities/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
+++ b/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
+++ b/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/compute_uncompute.py
+++ b/qiskit_machine_learning/state_fidelities/compute_uncompute.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/compute_uncompute.py
+++ b/qiskit_machine_learning/state_fidelities/compute_uncompute.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/state_fidelity_result.py
+++ b/qiskit_machine_learning/state_fidelities/state_fidelity_result.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/state_fidelities/state_fidelity_result.py
+++ b/qiskit_machine_learning/state_fidelities/state_fidelity_result.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/__init__.py
+++ b/qiskit_machine_learning/utils/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/adjust_num_qubits.py
+++ b/qiskit_machine_learning/utils/adjust_num_qubits.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/algorithm_globals.py
+++ b/qiskit_machine_learning/utils/algorithm_globals.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/algorithm_globals.py
+++ b/qiskit_machine_learning/utils/algorithm_globals.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/circuit_hash.py
+++ b/qiskit_machine_learning/utils/circuit_hash.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/circuit_hash.py
+++ b/qiskit_machine_learning/utils/circuit_hash.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/deprecation.py
+++ b/qiskit_machine_learning/utils/deprecation.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024, 2024.
+# (C) Copyright IBM 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/deprecation.py
+++ b/qiskit_machine_learning/utils/deprecation.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2024, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/loss_functions/__init__.py
+++ b/qiskit_machine_learning/utils/loss_functions/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/loss_functions/kernel_loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/kernel_loss_functions.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/optionals.py
+++ b/qiskit_machine_learning/utils/optionals.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/set_batching.py
+++ b/qiskit_machine_learning/utils/set_batching.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/set_batching.py
+++ b/qiskit_machine_learning/utils/set_batching.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/validate_bounds.py
+++ b/qiskit_machine_learning/utils/validate_bounds.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/validate_bounds.py
+++ b/qiskit_machine_learning/utils/validate_bounds.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/validate_initial_point.py
+++ b/qiskit_machine_learning/utils/validate_initial_point.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/validate_initial_point.py
+++ b/qiskit_machine_learning/utils/validate_initial_point.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/validation.py
+++ b/qiskit_machine_learning/utils/validation.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/utils/validation.py
+++ b/qiskit_machine_learning/utils/validation.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/variational_algorithm.py
+++ b/qiskit_machine_learning/variational_algorithm.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/variational_algorithm.py
+++ b/qiskit_machine_learning/variational_algorithm.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_fidelity_quantum_kernel_pegasos_qsvc.py
+++ b/test/algorithms/classifiers/test_fidelity_quantum_kernel_pegasos_qsvc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_fidelity_quantum_kernel_qsvc.py
+++ b/test/algorithms/classifiers/test_fidelity_quantum_kernel_qsvc.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_fidelity_quantum_kernel_qsvc.py
+++ b/test/algorithms/classifiers/test_fidelity_quantum_kernel_qsvc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_pegasos_qsvc.py
+++ b/test/algorithms/classifiers/test_pegasos_qsvc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_qsvc.py
+++ b/test/algorithms/classifiers/test_qsvc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/inference/__init__.py
+++ b/test/algorithms/inference/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/inference/__init__.py
+++ b/test/algorithms/inference/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/inference/test_qbayesian.py
+++ b/test/algorithms/inference/test_qbayesian.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/inference/test_qbayesian.py
+++ b/test/algorithms/inference/test_qbayesian.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py
+++ b/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py
+++ b/test/algorithms/regressors/test_fidelity_quantum_kernel_qsvr.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_neural_network_regressor.py
+++ b/test/algorithms/regressors/test_neural_network_regressor.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_qsvr.py
+++ b/test/algorithms/regressors/test_qsvr.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms_test_case.py
+++ b/test/algorithms_test_case.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms_test_case.py
+++ b/test/algorithms_test_case.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/circuit/test_qnn_circuit.py
+++ b/test/circuit/test_qnn_circuit.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/circuit/test_qnn_circuit.py
+++ b/test/circuit/test_qnn_circuit.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/circuit/test_raw_feature_vector.py
+++ b/test/circuit/test_raw_feature_vector.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/circuit/test_raw_feature_vector.py
+++ b/test/circuit/test_raw_feature_vector.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/connectors/test_torch.py
+++ b/test/connectors/test_torch.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/connectors/test_torch.py
+++ b/test/connectors/test_torch.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/connectors/test_torch_connector.py
+++ b/test/connectors/test_torch_connector.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/connectors/test_torch_networks.py
+++ b/test/connectors/test_torch_networks.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/connectors/test_torch_networks.py
+++ b/test/connectors/test_torch_networks.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/__init__.py
+++ b/test/datasets/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/__init__.py
+++ b/test/datasets/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/test_ad_hoc_data.py
+++ b/test/datasets/test_ad_hoc_data.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/test_ad_hoc_data.py
+++ b/test/datasets/test_ad_hoc_data.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/test_entanglement_concentration.py
+++ b/test/datasets/test_entanglement_concentration.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/test_entanglement_concentration.py
+++ b/test/datasets/test_entanglement_concentration.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2017, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2017, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2017, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/__init__.py
+++ b/test/gradients/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/__init__.py
+++ b/test/gradients/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/logging_primitives.py
+++ b/test/gradients/logging_primitives.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/logging_primitives.py
+++ b/test/gradients/logging_primitives.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_estimator_gradient.py
+++ b/test/gradients/test_estimator_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_estimator_gradient.py
+++ b/test/gradients/test_estimator_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_qfi.py
+++ b/test/gradients/test_qfi.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_qfi.py
+++ b/test/gradients/test_qfi.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_qgt.py
+++ b/test/gradients/test_qgt.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_qgt.py
+++ b/test/gradients/test_qgt.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_sampler_gradient.py
+++ b/test/gradients/test_sampler_gradient.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/gradients/test_sampler_gradient.py
+++ b/test/gradients/test_sampler_gradient.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/algorithms/test_fidelity_qkernel_trainer.py
+++ b/test/kernels/algorithms/test_fidelity_qkernel_trainer.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_fidelity_qkernel.py
+++ b/test/kernels/test_fidelity_qkernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_fidelity_qkernel.py
+++ b/test/kernels/test_fidelity_qkernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2023, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2023, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_trainable_fidelity_qkernel.py
+++ b/test/kernels/test_trainable_fidelity_qkernel.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_trainable_fidelity_qkernel.py
+++ b/test/kernels/test_trainable_fidelity_qkernel.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/machine_learning_test_case.py
+++ b/test/machine_learning_test_case.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/machine_learning_test_case.py
+++ b/test/machine_learning_test_case.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/neural_networks/test_effective_dimension.py
+++ b/test/neural_networks/test_effective_dimension.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/neural_networks/test_estimator_qnn.py
+++ b/test/neural_networks/test_estimator_qnn.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/__init__.py
+++ b/test/optimizers/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/__init__.py
+++ b/test/optimizers/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_adam_amsgrad.py
+++ b/test/optimizers/test_adam_amsgrad.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_adam_amsgrad.py
+++ b/test/optimizers/test_adam_amsgrad.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_gradient_descent.py
+++ b/test/optimizers/test_gradient_descent.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_gradient_descent.py
+++ b/test/optimizers/test_gradient_descent.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_gsls.py
+++ b/test/optimizers/test_gsls.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_gsls.py
+++ b/test/optimizers/test_gsls.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_nft.py
+++ b/test/optimizers/test_nft.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_nft.py
+++ b/test/optimizers/test_nft.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_nlopts.py
+++ b/test/optimizers/test_nlopts.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_nlopts.py
+++ b/test/optimizers/test_nlopts.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_optimizer_aqgd.py
+++ b/test/optimizers/test_optimizer_aqgd.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_optimizer_aqgd.py
+++ b/test/optimizers/test_optimizer_aqgd.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2018, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_optimizers.py
+++ b/test/optimizers/test_optimizers.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2018, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_spsa.py
+++ b/test/optimizers/test_spsa.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_umda.py
+++ b/test/optimizers/test_umda.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/test_umda.py
+++ b/test/optimizers/test_umda.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/utils/__init__.py
+++ b/test/optimizers/utils/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/utils/__init__.py
+++ b/test/optimizers/utils/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/utils/test_learning_rate.py
+++ b/test/optimizers/utils/test_learning_rate.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/optimizers/utils/test_learning_rate.py
+++ b/test/optimizers/utils/test_learning_rate.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/primitives/__init__.py
+++ b/test/primitives/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/primitives/__init__.py
+++ b/test/primitives/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/primitives/test_estimator.py
+++ b/test/primitives/test_estimator.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/primitives/test_estimator.py
+++ b/test/primitives/test_estimator.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/primitives/test_sampler.py
+++ b/test/primitives/test_sampler.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
+# (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/primitives/test_sampler.py
+++ b/test/primitives/test_sampler.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/state_fidelities/__init__.py
+++ b/test/state_fidelities/__init__.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/state_fidelities/__init__.py
+++ b/test/state_fidelities/__init__.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/state_fidelities/test_compute_uncompute.py
+++ b/test/state_fidelities/test_compute_uncompute.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/state_fidelities/test_compute_uncompute.py
+++ b/test/state_fidelities/test_compute_uncompute.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/loss_functions/test_regression_kernel_loss.py
+++ b/test/utils/loss_functions/test_regression_kernel_loss.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_adjust_num_qubits.py
+++ b/test/utils/test_adjust_num_qubits.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_algorithm_globals.py
+++ b/test/utils/test_algorithm_globals.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_algorithm_globals.py
+++ b/test/utils/test_algorithm_globals.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_circuit_hashing.py
+++ b/test/utils/test_circuit_hashing.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2025, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2025, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_set_batching.py
+++ b/test/utils/test_set_batching.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_set_batching.py
+++ b/test/utils/test_set_batching.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_validate_bounds.py
+++ b/test/utils/test_validate_bounds.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_validate_bounds.py
+++ b/test/utils/test_validate_bounds.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_validate_initial_point.py
+++ b/test/utils/test_validate_initial_point.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_validate_initial_point.py
+++ b/test/utils/test_validate_initial_point.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2022, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_validation.py
+++ b/test/utils/test_validation.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2024.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
+# (C) Copyright IBM 2019, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/utils/test_validation.py
+++ b/test/utils/test_validation.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2019, 2024.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -173,12 +173,13 @@ class CopyrightChecker:
                 )
 
                 if stfc_missing:
-                    if last_year < self._STFC_COPYRIGHT_YEAR and self._check:
-                        print(
-                            f"STFC copyright missing:'{relative_path}'",
-                            f"however last year {last_year}",
-                            f"< _STFC_COPYRIGHT_YEAR {self._STFC_COPYRIGHT_YEAR}... skipping",
-                        )
+                    if last_year < self._STFC_COPYRIGHT_YEAR:
+                        if self._check:
+                            print(
+                                f"STFC copyright missing:'{relative_path}'",
+                                f"however last year {last_year}",
+                                f"< _STFC_COPYRIGHT_YEAR {self._STFC_COPYRIGHT_YEAR}... skipping",
+                            )
                     else:
                         stfc_start_year = max(self._STFC_COPYRIGHT_YEAR, ibm_start_year)
                         stfc_line = new_line(

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2025.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -26,7 +26,9 @@ class CopyrightChecker:
     """Check copyright"""
 
     _UTF_STRING = "# -*- coding: utf-8 -*-"
-    _COPYRIGHT_STRING = "# (C) Copyright IBM "
+    _IBM_COPYRIGHT_STRING = "# (C) Copyright IBM "
+    _STFC_COPYRIGHT_STRING = "# (C) Copyright UKRI-STFC (Hartree Centre) "
+    _STFC_COPYRIGHT_YEAR = 2024
 
     def __init__(self, root_dir: str, check: bool) -> None:
         self._root_dir = root_dir
@@ -100,77 +102,136 @@ class CopyrightChecker:
 
     def check_copyright(self, file_path) -> Tuple[bool, bool, bool]:
         """check copyright for a file"""
+
+        def get_years(line) -> Tuple[int, int]:
+            """parse start and end years from line"""
+            curr_years = []
+            for word in line.strip().split():
+                for year in word.strip().split(","):
+                    if year.startswith("20") and len(year) >= 4:
+                        try:
+                            curr_years.append(int(year[0:4]))
+                        except ValueError:
+                            pass
+            if len(curr_years) > 1:
+                return curr_years[0], curr_years[1]
+            if len(curr_years) == 1:
+                return curr_years[0], curr_years[0]
+            return None, None
+
+        def new_line(copyright_string, start_year, last_year) -> str:
+            """create new copyright line"""
+            if start_year and start_year != last_year:
+                new_line = f"{copyright_string}{start_year}, {last_year}.\n"
+            else:
+                new_line = f"{copyright_string}{last_year}.\n"
+
+            return new_line
+
         file_with_utf8 = False
         file_with_invalid_year = False
         file_has_header = False
+        line_changes = []
         try:
-            new_line = "# (C) Copyright IBM "
             idx_utf8 = -1
-            idx_new_line = -1
             file_lines = None
             with open(file_path, "rt", encoding="utf8") as file:
                 file_lines = file.readlines()
-            for idx, line in enumerate(file_lines):
+            for ibm_idx, line in enumerate(file_lines):
                 relative_path = os.path.relpath(file_path, self._root_dir)
                 if line.startswith(CopyrightChecker._UTF_STRING):
                     if self._check:
                         print(f"File contains utf-8 header: '{relative_path}'")
                     file_with_utf8 = True
-                    idx_utf8 = idx
+                    idx_utf8 = ibm_idx
 
-                if not line.startswith(CopyrightChecker._COPYRIGHT_STRING):
+                if not line.startswith(CopyrightChecker._IBM_COPYRIGHT_STRING):
                     continue
 
                 file_has_header = True
-                curr_years = []
-                for word in line.strip().split():
-                    for year in word.strip().split(","):
-                        if year.startswith("20") and len(year) >= 4:
-                            try:
-                                curr_years.append(int(year[0:4]))
-                            except ValueError:
-                                pass
-
-                header_start_year = None
-                header_last_year = None
-                if len(curr_years) > 1:
-                    header_start_year = curr_years[0]
-                    header_last_year = curr_years[1]
-                elif len(curr_years) == 1:
-                    header_start_year = header_last_year = curr_years[0]
 
                 if relative_path in self._changed_files:
-                    self._changed_files.remove(relative_path)
                     last_year = self._current_year
                 else:
                     last_year = self._get_file_last_year(relative_path)
-                if last_year and header_last_year != last_year:
-                    if header_start_year and header_start_year != last_year:
-                        new_line += f"{header_start_year}, "
 
-                    new_line += f"{self._current_year}.\n"
+                ibm_start_year, _ = get_years(file_lines[ibm_idx])
+                ibm_line = new_line(self._IBM_COPYRIGHT_STRING, ibm_start_year, last_year)
+
+                if file_lines[ibm_idx] != ibm_line:
                     if self._check:
                         print(
                             f"Wrong Copyright Year:'{relative_path}': ",
-                            f"Current:'{line[:-1]}' Correct:'{new_line[:-1]}'",
+                            f"Current:'{file_lines[ibm_idx][:-1]}' Correct:'{ibm_line[:-1]}'",
                         )
                     file_with_invalid_year = True
-                    idx_new_line = idx
+                    line_changes.append(("replace", ibm_idx, ibm_line))
+
+                stfc_idx = ibm_idx + 1
+                stfc_missing = not file_lines[stfc_idx].startswith(
+                    CopyrightChecker._STFC_COPYRIGHT_STRING
+                )
+
+                if stfc_missing:
+                    if last_year < self._STFC_COPYRIGHT_YEAR and self._check:
+                        print(
+                            f"STFC copyright missing:'{relative_path}'",
+                            f"however last year {last_year}",
+                            f"< _STFC_COPYRIGHT_YEAR {self._STFC_COPYRIGHT_YEAR}... skipping",
+                        )
+                    else:
+                        stfc_start_year = max(self._STFC_COPYRIGHT_YEAR, ibm_start_year)
+                        stfc_line = new_line(
+                            self._STFC_COPYRIGHT_STRING, stfc_start_year, last_year
+                        )
+
+                        if self._check:
+                            print(
+                                f"STFC copyright missing:'{relative_path}'",
+                                f"Current IBM line:'{file_lines[ibm_idx][:-1]}'",
+                                f"Correct STFC line:'{stfc_line[:-1]}'",
+                            )
+                        file_with_invalid_year = True
+                        line_changes.append(("insert", stfc_idx, stfc_line))
+                else:
+                    stfc_start_year, _ = get_years(file_lines[stfc_idx])
+                    stfc_start_year = max(
+                        self._STFC_COPYRIGHT_YEAR, stfc_start_year, ibm_start_year
+                    )
+                    stfc_line = new_line(self._STFC_COPYRIGHT_STRING, stfc_start_year, last_year)
+
+                    if file_lines[stfc_idx] != stfc_line:
+                        if self._check:
+                            print(
+                                f"Wrong Copyright Year:'{relative_path}': ",
+                                f"Current:'{file_lines[stfc_idx][:-1]}'",
+                                f"Correct:'{stfc_line[:-1]}'",
+                            )
+                        file_with_invalid_year = True
+                        line_changes.append(("replace", stfc_idx, stfc_line))
+
+                if not self._check and (idx_utf8 >= 0 or line_changes):
+                    for to_do, idx_new_line, line in line_changes:
+                        if to_do == "insert":
+                            file_lines.insert(idx_new_line, line)
+                            print(f"Added STFC copyright for {relative_path}.")
+                        else:
+                            if file_lines[idx_new_line].startswith(self._IBM_COPYRIGHT_STRING):
+                                print(f"Fixed IBM copyright year for {relative_path}.")
+                            else:
+                                print(f"Fixed STFC copyright year for {relative_path}.")
+
+                            file_lines[idx_new_line] = line
+
+                    if idx_utf8 >= 0:
+                        del file_lines[idx_utf8]
+                        file_with_utf8 = False
+                        print(f"Removed utf-8 header for {relative_path}.")
+
+                    with open(file_path, "w", encoding="utf8") as file:
+                        file.writelines(file_lines)
 
                 break
-            if not self._check and (idx_utf8 >= 0 or idx_new_line >= 0):
-                if idx_new_line >= 0:
-                    file_lines[idx_new_line] = new_line
-                if idx_utf8 >= 0:
-                    del file_lines[idx_utf8]
-                with open(file_path, "w", encoding="utf8") as file:
-                    file.writelines(file_lines)
-                if idx_new_line >= 0:
-                    file_with_invalid_year = False
-                    print(f"Fixed copyright year for {relative_path}.")
-                if idx_utf8 >= 0:
-                    file_with_utf8 = False
-                    print(f"Removed utf-8 header for {relative_path}.")
 
         except UnicodeDecodeError:
             return file_with_utf8, file_with_invalid_year, file_has_header

--- a/tools/extract_deprecation.py
+++ b/tools/extract_deprecation.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/extract_deprecation.py
+++ b/tools/extract_deprecation.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/find_stray_release_notes.py
+++ b/tools/find_stray_release_notes.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/find_stray_release_notes.py
+++ b/tools/find_stray_release_notes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/generate_spell_dict.py
+++ b/tools/generate_spell_dict.py
@@ -1,7 +1,7 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
-# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
+# (C) Copyright IBM 2021, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/generate_spell_dict.py
+++ b/tools/generate_spell_dict.py
@@ -1,6 +1,7 @@
 # This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2025.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -45,6 +45,23 @@ def discover_files(code_paths, exclude_folders):
     return out_paths
 
 
+def get_years(line):
+    """Return first and last year for copyright line"""
+    curr_years = []
+    for word in line.strip().split():
+        for year in word.strip().split(","):
+            if year.startswith("20") and len(year) >= 4:
+                try:
+                    curr_years.append(int(year[0:4]))
+                except ValueError:
+                    pass
+    if len(curr_years) > 1:
+        return curr_years[0], curr_years[1]
+    if len(curr_years) == 1:
+        return curr_years[0], curr_years[0]
+    return None, None
+
+
 def validate_header(file_path):
     """Validate the header for a single file"""
     header = """# This code is part of a Qiskit project.
@@ -59,26 +76,50 @@ def validate_header(file_path):
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
-    count = 0
+
     with open(file_path, encoding="utf8") as code_file:
         lines = code_file.readlines()
+
+    stfc_year = 2024
+    count = 0
     start = 0
+    reason = None
+    passed = True
     for index, line in enumerate(lines):
         count += 1
         if count > 5:
-            return file_path, False, "Header not found in first 5 lines"
+            reason = "Header not found in first 5 lines"
+            passed = False
         if count <= 2 and pep263.match(line):
-            return file_path, False, "Unnecessary encoding specification (PEP 263, 3120)"
-        if line == "# This code is part of a Qiskit project.\n":
+            reason = "Unnecessary encoding specification (PEP 263, 3120)"
+            passed = False
+        if passed and line == "# This code is part of a Qiskit project.\n":
             start = index
             break
-    if "".join(lines[start : start + 2]) != header:
-        return file_path, False, f"Header up to copyright line does not match: {header}"
-    if not lines[start + 2].startswith("# (C) Copyright IBM 20"):
-        return file_path, False, "Header copyright line not found"
-    if "".join(lines[start + 3 : start + 11]) != apache_text:
-        return file_path, False, f"Header apache text string doesn't match:\n {apache_text}"
-    return file_path, True, None
+
+    if passed and "".join(lines[start : start + 2]) != header:
+        reason = f"Header up to copyright line does not match: {header}"
+        passed = False
+
+    if passed and not lines[start + 2].startswith("# (C) Copyright IBM 20"):
+        reason = "Header IBM copyright line not found"
+        passed = False
+
+    _, ibm_last_year = get_years(lines[start + 2])
+    if passed and ibm_last_year >= stfc_year:
+        if not lines[start + 3].startswith("# (C) Copyright UKRI-STFC (Hartree Centre) 20"):
+            reason = "Header STFC copyright line not found"
+            passed = False
+
+        if passed and "".join(lines[start + 4 : start + 12]) != apache_text:
+            reason = f"Header apache text string doesn't match:\n {apache_text}"
+            passed = False
+    elif passed and ibm_last_year < stfc_year:
+        if "".join(lines[start + 3 : start + 11]) != apache_text:
+            reason = f"Header apache text string doesn't match:\n {apache_text}"
+            passed = False
+
+    return file_path, passed, reason
 
 
 def _main():

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2024, 2026.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
- Added checks for '(C) Copyright UKRI-STFC (Hartree Centre)' copyright.
- Updated headers check to account for the STFC copyright

### Details and comments
#### check_copyright.py
 - STFC copyright year started in 2024 so earliest this copyright can be added is 2024. If there is an IBM copyright that is less than this year then it will not require an STFC copyright until this file has been updated and the latest year would be >= 2024. 
 - Since we need the ability to both add a new STFC copyright line as well as check existing ones there is checks for both inserting a new line and replacing the current line.
 - To avoid duplicating code I created the `get_years` and `new_line` functions.

#### verify_headers.py
- pylint didn't like the large number of return statements within verify_header.py so I had to change the function to reduce the number of returns.
- Again it checks if the file copyright is >=2024 otherwise the STFC header is not necassary until the file has been updated.
- Because some headers can inlcude the STFC copyright while others don't, there needs to be the seperate Apache lines check since the line numbers will be different in each case. 

