### PR TITLE
fix mypy test failure due to non-typed mapping

### DIFF
--- a/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
+++ b/qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Sequence
+from typing import Sequence, Mapping, Type
 
 import numpy as np
 
@@ -251,7 +251,7 @@ class QuantumKernelTrainer:
 
     def _str_to_loss(self, loss_str: str) -> KernelLoss:
         """Function which maps strings to default KernelLoss objects."""
-        string_to_loss_map = {
+        string_to_loss_map: Mapping[str, Type[KernelLoss]] = {
             "svc_loss": SVCLoss,
             "svr_loss": SVRLoss,
             "msr_loss": MSRLoss,


### PR DESCRIPTION
### Summary

Fix for https://github.com/qiskit-community/qiskit-machine-learning/issues/1038.

### Details and comments

Running `make mypy` fails with error message:

```qiskit_machine_learning/kernels/algorithms/quantum_kernel_trainer.py:263: error: Cannot instantiate abstract class "KernelLoss" with abstract attribute "evaluate"  [abstract]```

This is a known issue/feature of mypy (https://stackoverflow.com/questions/54241721/mypy-issues-with-abstract-classes-and-dictionaries) and is caused by the `string_to_loss_map` dictionary on line 254 of `quantum_kernel_trainer.py` not having declared types.


