### PR TITLE
Nightly tests failing around multidimensional sparse COO

### DIFF
--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -303,7 +303,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
                 grad.shape
             )
             diff = input_grad_ - grad
-            self.assertAlmostEqual(np.max(np.abs(diff)), 0.0, places=3)
+            self.assertAlmostEqual(float(np.max(np.abs(diff))), 0.0, places=3)
 
         # test weight gradients
         eps = 1e-2
@@ -319,7 +319,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
                 :, :, k
             ].reshape(grad.shape)
             diff = weights_grad_ - grad
-            self.assertAlmostEqual(np.max(np.abs(diff)), 0.0, places=3)
+            self.assertAlmostEqual(float(np.max(np.abs(diff))), 0.0, places=3)
 
     def test_setters_getters(self):
         """Test Sampler QNN properties."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1051

### Details and comments
There was a unit test failure where extracting maximum absolute value from multidimensional sparse COO did not return a scalar but instead an COO object with `shape=()`. Subsequently `assertAlmostEqual` failed because it is unable to apply `round` to COO object.

This is a simple fix, where for the test cases which expect scalar we explicitly cast argument to float, extracting scalar value stored inside `fill_value`.
