### PR TITLE
Stabilize Runtime-backed unit tests against CI flakes.

### DIFF
--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -21,17 +21,18 @@ import unittest
 from dataclasses import dataclass
 from test import QiskitMachineLearningTestCase
 
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_runtime_pass_manager,
+    make_sampler_v2,
+)
+
 import numpy as np
 import scipy
 from ddt import ddt, idata, unpack
 from sklearn.datasets import make_classification
 from sklearn.preprocessing import MinMaxScaler, OneHotEncoder
 from qiskit.circuit.library import real_amplitudes, z_feature_map, zz_feature_map
-from test.utils.runtime_simulation import (
-    DEFAULT_RUNTIME_SEED,
-    make_runtime_pass_manager,
-    make_sampler_v2,
-)
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 from qiskit_machine_learning.algorithms import VQC
 from qiskit_machine_learning.exceptions import QiskitMachineLearningError

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -27,9 +27,11 @@ from ddt import ddt, idata, unpack
 from sklearn.datasets import make_classification
 from sklearn.preprocessing import MinMaxScaler, OneHotEncoder
 from qiskit.circuit.library import real_amplitudes, z_feature_map, zz_feature_map
-from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit_ibm_runtime import SamplerV2, Session
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_runtime_pass_manager,
+    make_sampler_v2,
+)
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 from qiskit_machine_learning.algorithms import VQC
 from qiskit_machine_learning.exceptions import QiskitMachineLearningError
@@ -75,12 +77,9 @@ class TestVQC(QiskitMachineLearningTestCase):
         super().setUp()
         algorithm_globals.random_seed = 1111111
         self.num_classes_by_batch = []
-        self.backend = GenericBackendV2(
-            num_qubits=3,
-            noise_info=False,
-            seed=123,
+        self.backend, _, runtime_sampler = make_sampler_v2(
+            3, seed=DEFAULT_RUNTIME_SEED, default_shots=10000
         )
-        self.session = Session(backend=self.backend)
         # We want string keys to ensure DDT-generated tests have meaningful names.
         self.properties = {
             "cobyla": COBYLA(maxiter=25),
@@ -89,7 +88,7 @@ class TestVQC(QiskitMachineLearningTestCase):
             "binary": _create_dataset(6, 2),
             "multiclass": _create_dataset(10, 3),
             "no_one_hot": _create_dataset(6, 2, one_hot=False),
-            "runtime_sampler": SamplerV2(mode=self.session, options={"default_shots": 10000}),
+            "runtime_sampler": runtime_sampler,
             "QMLSampler": Sampler(),
         }
 
@@ -104,7 +103,9 @@ class TestVQC(QiskitMachineLearningTestCase):
         instances, numbers of qubits, feature maps, and optimizers.
         """
         if smplr == "runtime_sampler":
-            pm = generate_preset_pass_manager(optimization_level=0, backend=self.backend)
+            pm = make_runtime_pass_manager(
+                self.backend, optimization_level=0, seed=DEFAULT_RUNTIME_SEED
+            )
         else:
             pm = None
 

--- a/test/algorithms/inference/test_qbayesian.py
+++ b/test/algorithms/inference/test_qbayesian.py
@@ -16,15 +16,15 @@
 import unittest
 from test import QiskitMachineLearningTestCase
 
-import numpy as np
-from qiskit import QuantumCircuit
-from qiskit.circuit import QuantumRegister
-
 from test.utils.runtime_simulation import (
     DEFAULT_RUNTIME_SEED,
     make_runtime_pass_manager,
     make_sampler_v2,
 )
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit import QuantumRegister
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 from qiskit_machine_learning.algorithms import QBayesian
 from qiskit_machine_learning.utils import algorithm_globals

--- a/test/algorithms/inference/test_qbayesian.py
+++ b/test/algorithms/inference/test_qbayesian.py
@@ -20,10 +20,11 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 
-from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit_ibm_runtime import SamplerV2, Session
-from qiskit_ibm_runtime.options import SamplerOptions, SimulatorOptions
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_runtime_pass_manager,
+    make_sampler_v2,
+)
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 from qiskit_machine_learning.algorithms import QBayesian
 from qiskit_machine_learning.utils import algorithm_globals
@@ -217,17 +218,9 @@ class TestQBayesianInference(QiskitMachineLearningTestCase):
     def test_trivial_circuit_V2(self):
         """Tests trivial quantum circuit for V2 primitives"""
 
-        backend = GenericBackendV2(
-            num_qubits=2,
-            noise_info=False,
-            seed=123,
-        )
-        session = Session(backend=backend)
-        simopts = SimulatorOptions(seed_simulator=123)
-        samopts = SamplerOptions(simulator=simopts)
-        _sampler = SamplerV2(mode=session, options=samopts)
-        pass_manager = generate_preset_pass_manager(
-            optimization_level=0, backend=backend, seed_transpiler=123
+        backend, _, _sampler = make_sampler_v2(2, seed=DEFAULT_RUNTIME_SEED)
+        pass_manager = make_runtime_pass_manager(
+            backend, optimization_level=0, seed=DEFAULT_RUNTIME_SEED
         )
 
         # Define rotation angles

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -18,9 +18,11 @@ from test import QiskitMachineLearningTestCase
 import numpy as np
 from ddt import data, ddt
 from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit_ibm_runtime import EstimatorV2, Session
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_estimator_v2,
+    make_runtime_pass_manager,
+)
 from qiskit_machine_learning.primitives import QMLEstimator as Estimator
 from qiskit_machine_learning.algorithms import VQR
 from qiskit_machine_learning.optimizers import COBYLA, L_BFGS_B
@@ -140,14 +142,10 @@ class TestVQR(QiskitMachineLearningTestCase):
         else:
             optimizer = None
 
-        backend = GenericBackendV2(
-            num_qubits=2,
-            noise_info=False,
-            seed=123,
+        backend, _estimator = make_estimator_v2(2, seed=DEFAULT_RUNTIME_SEED)
+        pass_manager = make_runtime_pass_manager(
+            backend, optimization_level=0, seed=DEFAULT_RUNTIME_SEED
         )
-        session = Session(backend=backend)
-        _estimator = EstimatorV2(mode=session)
-        pass_manager = generate_preset_pass_manager(optimization_level=0, backend=backend)
 
         num_qubits = 1
         # construct simple feature map

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -15,14 +15,15 @@
 import unittest
 from test import QiskitMachineLearningTestCase
 
-import numpy as np
-from ddt import data, ddt
-from qiskit.circuit import Parameter, QuantumCircuit
 from test.utils.runtime_simulation import (
     DEFAULT_RUNTIME_SEED,
     make_estimator_v2,
     make_runtime_pass_manager,
 )
+
+import numpy as np
+from ddt import data, ddt
+from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit_machine_learning.primitives import QMLEstimator as Estimator
 from qiskit_machine_learning.algorithms import VQR
 from qiskit_machine_learning.optimizers import COBYLA, L_BFGS_B

--- a/test/gradients/test_estimator_gradient.py
+++ b/test/gradients/test_estimator_gradient.py
@@ -24,11 +24,12 @@ from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import efficient_su2, real_amplitudes
 from qiskit.circuit.library.standard_gates import RXXGate, RYYGate, RZXGate, RZZGate
-from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit_ibm_runtime import EstimatorV2, Session
-from qiskit_ibm_runtime.options import EstimatorOptions, SimulatorOptions
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_estimator_v2,
+    make_runtime_pass_manager,
+)
 from qiskit_machine_learning.gradients import (
     LinCombEstimatorGradient,
     ParamShiftEstimatorGradient,
@@ -403,12 +404,10 @@ class TestEstimatorGradientRuntime(QiskitAlgorithmsTestCase):
     """Test Estimator Gradient for IBM Runtime"""
 
     def __init__(self, TestCase):
-        backend = GenericBackendV2(num_qubits=3, seed=123)
-        session = Session(backend=backend)
-        simopts = SimulatorOptions(seed_simulator=123)
-        estopts = EstimatorOptions(simulator=simopts)
-        self.estimator = EstimatorV2(mode=session, options=estopts)
-        self.pass_manager = generate_preset_pass_manager(optimization_level=1, backend=backend)
+        backend, self.estimator = make_estimator_v2(3, seed=DEFAULT_RUNTIME_SEED)
+        self.pass_manager = make_runtime_pass_manager(
+            backend, optimization_level=1, seed=DEFAULT_RUNTIME_SEED
+        )
         super().__init__(TestCase)
 
     @data(*gradient_factories)

--- a/test/gradients/test_estimator_gradient.py
+++ b/test/gradients/test_estimator_gradient.py
@@ -17,6 +17,11 @@
 import unittest
 from test import QiskitAlgorithmsTestCase
 from test.gradients.logging_primitives import LoggingEstimator
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_estimator_v2,
+    make_runtime_pass_manager,
+)
 
 import numpy as np
 from ddt import data, ddt
@@ -25,11 +30,6 @@ from qiskit.circuit import Parameter
 from qiskit.circuit.library import efficient_su2, real_amplitudes
 from qiskit.circuit.library.standard_gates import RXXGate, RYYGate, RZXGate, RZZGate
 from qiskit.quantum_info import SparsePauliOp
-from test.utils.runtime_simulation import (
-    DEFAULT_RUNTIME_SEED,
-    make_estimator_v2,
-    make_runtime_pass_manager,
-)
 from qiskit_machine_learning.gradients import (
     LinCombEstimatorGradient,
     ParamShiftEstimatorGradient,

--- a/test/gradients/test_sampler_gradient.py
+++ b/test/gradients/test_sampler_gradient.py
@@ -16,7 +16,6 @@
 
 import unittest
 from test import QiskitAlgorithmsTestCase
-from qiskit_ibm_runtime import SamplerV2, Session
 
 import numpy as np
 from ddt import data, ddt
@@ -26,7 +25,11 @@ from qiskit.circuit import Parameter
 from qiskit.circuit.library import efficient_su2, real_amplitudes
 from qiskit.circuit.library.standard_gates import RXXGate
 
-from qiskit.providers.fake_provider import GenericBackendV2
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_runtime_pass_manager,
+    make_sampler_v2,
+)
 from qiskit.result import QuasiDistribution
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
@@ -551,10 +554,10 @@ class TestSamplerGradientRuntime(QiskitAlgorithmsTestCase):
     """Test Sampler Gradient for IBM Runtime"""
 
     def __init__(self, TestCase):
-        backend = GenericBackendV2(num_qubits=3, seed=123)
-        session = Session(backend=backend)
-        self.sampler = SamplerV2(mode=session)
-        self.pass_manager = generate_preset_pass_manager(optimization_level=1, backend=backend)
+        backend, _, self.sampler = make_sampler_v2(3, seed=DEFAULT_RUNTIME_SEED)
+        self.pass_manager = make_runtime_pass_manager(
+            backend, optimization_level=1, seed=DEFAULT_RUNTIME_SEED
+        )
         super().__init__(TestCase)
 
     @data(*gradient_factories)

--- a/test/gradients/test_sampler_gradient.py
+++ b/test/gradients/test_sampler_gradient.py
@@ -16,6 +16,11 @@
 
 import unittest
 from test import QiskitAlgorithmsTestCase
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_runtime_pass_manager,
+    make_sampler_v2,
+)
 
 import numpy as np
 from ddt import data, ddt
@@ -25,14 +30,7 @@ from qiskit.circuit import Parameter
 from qiskit.circuit.library import efficient_su2, real_amplitudes
 from qiskit.circuit.library.standard_gates import RXXGate
 
-from test.utils.runtime_simulation import (
-    DEFAULT_RUNTIME_SEED,
-    make_runtime_pass_manager,
-    make_sampler_v2,
-)
 from qiskit.result import QuasiDistribution
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 from qiskit_machine_learning.gradients import (
     LinCombSamplerGradient,

--- a/test/neural_networks/test_estimator_qnn.py
+++ b/test/neural_networks/test_estimator_qnn.py
@@ -19,10 +19,12 @@ from test import QiskitMachineLearningTestCase
 import numpy as np
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import real_amplitudes, z_feature_map, zz_feature_map
-from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit_ibm_runtime import EstimatorV2, Session
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_estimator_v2,
+    make_runtime_pass_manager,
+)
 from qiskit_machine_learning.circuit.library import qnn_circuit
 from qiskit_machine_learning.gradients import ParamShiftEstimatorGradient
 from qiskit_machine_learning.neural_networks.estimator_qnn import EstimatorQNN
@@ -180,15 +182,17 @@ class TestEstimatorQNNV2(QiskitMachineLearningTestCase):
     """EstimatorQNN Tests for estimator_v2. The correct references is obtained from EstimatorQNN"""
 
     tolerance: dict[str, float] = dict(atol=3 * 1.0e-1, rtol=3 * 1.0e-1)
-    backend = GenericBackendV2(num_qubits=2, seed=123)
-    session = Session(backend=backend)
+    _backend, _estimator = make_estimator_v2(2, seed=DEFAULT_RUNTIME_SEED, default_shots=1000)
 
     def __init__(
         self,
         TestCase,
     ):
-        self.estimator = EstimatorV2(mode=self.session, options={"default_shots": 1e3})
-        self.pass_manager = generate_preset_pass_manager(backend=self.backend, optimization_level=0)
+        self.estimator = self._estimator
+        self.backend = self._backend
+        self.pass_manager = make_runtime_pass_manager(
+            self.backend, optimization_level=0, seed=DEFAULT_RUNTIME_SEED
+        )
         self.gradient = ParamShiftEstimatorGradient(
             estimator=self.estimator, pass_manager=self.pass_manager
         )

--- a/test/neural_networks/test_estimator_qnn.py
+++ b/test/neural_networks/test_estimator_qnn.py
@@ -16,15 +16,16 @@
 import unittest
 from test import QiskitMachineLearningTestCase
 
-import numpy as np
-from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.circuit.library import real_amplitudes, z_feature_map, zz_feature_map
-from qiskit.quantum_info import SparsePauliOp
 from test.utils.runtime_simulation import (
     DEFAULT_RUNTIME_SEED,
     make_estimator_v2,
     make_runtime_pass_manager,
 )
+
+import numpy as np
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.circuit.library import real_amplitudes, z_feature_map, zz_feature_map
+from qiskit.quantum_info import SparsePauliOp
 from qiskit_machine_learning.circuit.library import qnn_circuit
 from qiskit_machine_learning.gradients import ParamShiftEstimatorGradient
 from qiskit_machine_learning.neural_networks.estimator_qnn import EstimatorQNN

--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -25,10 +25,11 @@ from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import real_amplitudes, zz_feature_map
 
 # from qiskit.primitives import StatevectorSampler as Sampler
-from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-
-from qiskit_ibm_runtime import SamplerV2, Session
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_runtime_pass_manager,
+    make_sampler_v2,
+)
 
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 import qiskit_machine_learning.optionals as _optionals
@@ -104,9 +105,9 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
         # define sampler primitives
         self.sampler = Sampler()
         self.sampler_shots = Sampler(default_shots=100, seed=42)
-        self.backend = GenericBackendV2(num_qubits=8)
-        self.session = Session(backend=self.backend)
-        self.sampler_v2 = SamplerV2(mode=self.session)
+        self.backend, self.session, self.sampler_v2 = make_sampler_v2(
+            8, seed=DEFAULT_RUNTIME_SEED
+        )
         self.pass_manager = None
         self.array_type = {True: SparseArray, False: np.ndarray}
 
@@ -135,8 +136,8 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
             sampler = self.sampler_v2
 
             if self.qc.layout is None:
-                self.pass_manager = generate_preset_pass_manager(
-                    optimization_level=1, backend=self.backend
+                self.pass_manager = make_runtime_pass_manager(
+                    self.backend, optimization_level=1, seed=DEFAULT_RUNTIME_SEED
                 )
                 self.qc = self.pass_manager.run(self.qc)
             gradient = ParamShiftSamplerGradient(
@@ -404,7 +405,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
             interpret=parity,
             output_shape=2,
             input_gradients=True,
-            pass_manager=generate_preset_pass_manager(backend=self.backend),
+            pass_manager=make_runtime_pass_manager(self.backend, seed=DEFAULT_RUNTIME_SEED),
         )
         sampler_qc = SamplerQNN(
             circuit=qc,
@@ -469,9 +470,10 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
         # Transpile to an 8-qubit backend, forcing logical qubits
         # to physical positions [5, 7] — deliberately high to
         # trigger the bug
-        pm = generate_preset_pass_manager(
+        pm = make_runtime_pass_manager(
+            self.backend,
             optimization_level=1,
-            backend=self.backend,
+            seed=DEFAULT_RUNTIME_SEED,
             initial_layout=[5, 7],
         )
         transpiled = pm.run(qc)

--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -19,17 +19,16 @@ import itertools
 import unittest
 from test import QiskitMachineLearningTestCase
 
-import numpy as np
-from ddt import ddt, idata
-from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.circuit.library import real_amplitudes, zz_feature_map
-
-# from qiskit.primitives import StatevectorSampler as Sampler
 from test.utils.runtime_simulation import (
     DEFAULT_RUNTIME_SEED,
     make_runtime_pass_manager,
     make_sampler_v2,
 )
+
+import numpy as np
+from ddt import ddt, idata
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.circuit.library import real_amplitudes, zz_feature_map
 
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
 import qiskit_machine_learning.optionals as _optionals
@@ -512,7 +511,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
         # bitstrings, like real hardware or SamplerV2
         qnn = SamplerQNN(
             circuit=transpiled,
-            sampler=SamplerV2(mode=self.backend),
+            sampler=self.sampler_v2,
         )
 
         # Confirm the QNN sees 2 logical qubits, not 8

--- a/test/utils/runtime_simulation.py
+++ b/test/utils/runtime_simulation.py
@@ -1,0 +1,109 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Helpers for reproducible local IBM Runtime primitive tests."""
+
+from __future__ import annotations
+
+from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+from qiskit_ibm_runtime import EstimatorV2, SamplerV2, Session
+from qiskit_ibm_runtime.options import EstimatorOptions, SamplerOptions, SimulatorOptions
+
+DEFAULT_RUNTIME_SEED = 123
+
+
+def make_generic_backend(num_qubits: int, *, seed: int = DEFAULT_RUNTIME_SEED) -> GenericBackendV2:
+    """Return a noise-free fake backend with a fixed layout seed."""
+    return GenericBackendV2(num_qubits=num_qubits, noise_info=False, seed=seed)
+
+
+def make_simulator_options(*, seed: int = DEFAULT_RUNTIME_SEED) -> SimulatorOptions:
+    """Return simulator options for deterministic local Runtime execution."""
+    return SimulatorOptions(seed_simulator=seed)
+
+
+def make_estimator_options(
+    *, seed: int = DEFAULT_RUNTIME_SEED, default_shots: int | None = None
+) -> EstimatorOptions:
+    """Return EstimatorV2 options with deterministic simulation settings."""
+    options = EstimatorOptions(
+        simulator=make_simulator_options(seed=seed),
+        seed_estimator=seed,
+        resilience_level=0,
+    )
+    if default_shots is not None:
+        options.default_shots = default_shots
+    return options
+
+
+def make_sampler_options(
+    *, seed: int = DEFAULT_RUNTIME_SEED, default_shots: int | None = None
+) -> SamplerOptions:
+    """Return SamplerV2 options with deterministic simulation settings."""
+    options = SamplerOptions(simulator=make_simulator_options(seed=seed))
+    if default_shots is not None:
+        options.default_shots = default_shots
+    return options
+
+
+def make_runtime_session(
+    num_qubits: int, *, seed: int = DEFAULT_RUNTIME_SEED
+) -> tuple[GenericBackendV2, Session]:
+    """Create a backend and session for local Runtime primitive tests."""
+    backend = make_generic_backend(num_qubits, seed=seed)
+    return backend, Session(backend=backend)
+
+
+def make_runtime_pass_manager(
+    backend: GenericBackendV2,
+    *,
+    optimization_level: int = 0,
+    seed: int = DEFAULT_RUNTIME_SEED,
+    **kwargs,
+):
+    """Create a pass manager with a fixed transpiler seed."""
+    return generate_preset_pass_manager(
+        optimization_level=optimization_level,
+        backend=backend,
+        seed_transpiler=seed,
+        **kwargs,
+    )
+
+
+def make_estimator_v2(
+    num_qubits: int,
+    *,
+    seed: int = DEFAULT_RUNTIME_SEED,
+    default_shots: int | None = None,
+) -> tuple[GenericBackendV2, EstimatorV2]:
+    """Create a deterministic EstimatorV2 backed by a local fake backend."""
+    backend, session = make_runtime_session(num_qubits, seed=seed)
+    estimator = EstimatorV2(
+        mode=session,
+        options=make_estimator_options(seed=seed, default_shots=default_shots),
+    )
+    return backend, estimator
+
+
+def make_sampler_v2(
+    num_qubits: int,
+    *,
+    seed: int = DEFAULT_RUNTIME_SEED,
+    default_shots: int | None = None,
+) -> tuple[GenericBackendV2, Session, SamplerV2]:
+    """Create a deterministic SamplerV2 backed by a local fake backend."""
+    backend, session = make_runtime_session(num_qubits, seed=seed)
+    sampler = SamplerV2(
+        mode=session,
+        options=make_sampler_options(seed=seed, default_shots=default_shots),
+    )
+    return backend, session, sampler

--- a/test/utils/test_runtime_simulation.py
+++ b/test/utils/test_runtime_simulation.py
@@ -1,0 +1,49 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Tests for runtime simulation helpers."""
+
+from test import QiskitMachineLearningTestCase
+from test.utils.runtime_simulation import (
+    DEFAULT_RUNTIME_SEED,
+    make_estimator_options,
+    make_generic_backend,
+    make_sampler_options,
+    make_simulator_options,
+)
+
+
+class TestRuntimeSimulationHelpers(QiskitMachineLearningTestCase):
+    """Tests for deterministic Runtime test helpers."""
+
+    def test_backend_uses_fixed_seed(self):
+        """Generic backend helpers create a noise-free fake backend."""
+        backend = make_generic_backend(2)
+        self.assertEqual(backend.num_qubits, 2)
+
+    def test_simulator_options_use_fixed_seed(self):
+        """Simulator options pin the simulator seed."""
+        options = make_simulator_options()
+        self.assertEqual(options.seed_simulator, DEFAULT_RUNTIME_SEED)
+
+    def test_estimator_options_are_deterministic(self):
+        """Estimator options pin seeds and disable resilience mitigation."""
+        options = make_estimator_options(default_shots=1024)
+        self.assertEqual(options.seed_estimator, DEFAULT_RUNTIME_SEED)
+        self.assertEqual(options.resilience_level, 0)
+        self.assertEqual(options.default_shots, 1024)
+        self.assertEqual(options.simulator.seed_simulator, DEFAULT_RUNTIME_SEED)
+
+    def test_sampler_options_use_fixed_seed(self):
+        """Sampler options pin the simulator seed."""
+        options = make_sampler_options(default_shots=2048)
+        self.assertEqual(options.simulator.seed_simulator, DEFAULT_RUNTIME_SEED)
+        self.assertEqual(options.default_shots, 2048)

--- a/test/utils/test_runtime_simulation.py
+++ b/test/utils/test_runtime_simulation.py
@@ -11,28 +11,64 @@
 # that they have been altered from the originals.
 """Tests for runtime simulation helpers."""
 
+from unittest.mock import patch
+
 from test import QiskitMachineLearningTestCase
 from test.utils.runtime_simulation import (
     DEFAULT_RUNTIME_SEED,
     make_estimator_options,
+    make_estimator_v2,
     make_generic_backend,
+    make_runtime_pass_manager,
+    make_runtime_session,
     make_sampler_options,
+    make_sampler_v2,
     make_simulator_options,
 )
+
+from qiskit import QuantumCircuit
+from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit_ibm_runtime.options.utils import Unset
 
 
 class TestRuntimeSimulationHelpers(QiskitMachineLearningTestCase):
     """Tests for deterministic Runtime test helpers."""
 
-    def test_backend_uses_fixed_seed(self):
-        """Generic backend helpers create a noise-free fake backend."""
+    def test_generic_backend_has_expected_num_qubits(self):
+        """Generic backend helpers create a backend with the requested width."""
         backend = make_generic_backend(2)
         self.assertEqual(backend.num_qubits, 2)
+
+    def test_generic_backend_is_noise_free(self):
+        """Generic backend helpers disable injected noise metadata."""
+        backend = make_generic_backend(2)
+        noisy_backend = GenericBackendV2(num_qubits=2)
+        self.assertFalse(backend._noise_info)
+        self.assertTrue(noisy_backend._noise_info)
+
+    def test_generic_backend_forwards_seed(self):
+        """Layout seed is forwarded to GenericBackendV2."""
+        with patch("test.utils.runtime_simulation.GenericBackendV2") as mock_backend_cls:
+            make_generic_backend(3, seed=42)
+            mock_backend_cls.assert_called_once_with(num_qubits=3, noise_info=False, seed=42)
+
+    def test_generic_backend_uses_default_seed(self):
+        """Default layout seed matches DEFAULT_RUNTIME_SEED."""
+        with patch("test.utils.runtime_simulation.GenericBackendV2") as mock_backend_cls:
+            make_generic_backend(2)
+            mock_backend_cls.assert_called_once_with(
+                num_qubits=2, noise_info=False, seed=DEFAULT_RUNTIME_SEED
+            )
 
     def test_simulator_options_use_fixed_seed(self):
         """Simulator options pin the simulator seed."""
         options = make_simulator_options()
         self.assertEqual(options.seed_simulator, DEFAULT_RUNTIME_SEED)
+
+    def test_simulator_options_custom_seed(self):
+        """Simulator options accept a custom seed."""
+        options = make_simulator_options(seed=42)
+        self.assertEqual(options.seed_simulator, 42)
 
     def test_estimator_options_are_deterministic(self):
         """Estimator options pin seeds and disable resilience mitigation."""
@@ -42,8 +78,60 @@ class TestRuntimeSimulationHelpers(QiskitMachineLearningTestCase):
         self.assertEqual(options.default_shots, 1024)
         self.assertEqual(options.simulator.seed_simulator, DEFAULT_RUNTIME_SEED)
 
+    def test_estimator_options_without_default_shots(self):
+        """Estimator options omit default_shots when not requested."""
+        options = make_estimator_options()
+        self.assertIs(options.default_shots, Unset)
+
     def test_sampler_options_use_fixed_seed(self):
         """Sampler options pin the simulator seed."""
         options = make_sampler_options(default_shots=2048)
         self.assertEqual(options.simulator.seed_simulator, DEFAULT_RUNTIME_SEED)
         self.assertEqual(options.default_shots, 2048)
+
+    def test_sampler_options_without_default_shots(self):
+        """Sampler options omit default_shots when not requested."""
+        options = make_sampler_options()
+        self.assertIs(options.default_shots, Unset)
+
+    def test_make_runtime_session(self):
+        """Session helper returns a backend and session for the requested width."""
+        backend, session = make_runtime_session(3, seed=DEFAULT_RUNTIME_SEED)
+        self.assertEqual(backend.num_qubits, 3)
+        self.assertIsNotNone(session)
+
+    def test_make_runtime_pass_manager_is_reproducible(self):
+        """Pass manager helper transpiles with a fixed transpiler seed."""
+        backend = make_generic_backend(2, seed=DEFAULT_RUNTIME_SEED)
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.measure_all()
+        pass_manager = make_runtime_pass_manager(backend, seed=DEFAULT_RUNTIME_SEED)
+        transpiled_a = pass_manager.run(circuit)
+        transpiled_b = pass_manager.run(circuit)
+        self.assertEqual(
+            transpiled_a.layout.final_index_layout(),
+            transpiled_b.layout.final_index_layout(),
+        )
+
+    def test_make_estimator_v2(self):
+        """Estimator helper wires deterministic options and optional default shots."""
+        backend, estimator = make_estimator_v2(2, seed=DEFAULT_RUNTIME_SEED, default_shots=512)
+        self.assertEqual(backend.num_qubits, 2)
+        self.assertEqual(estimator.options.seed_estimator, DEFAULT_RUNTIME_SEED)
+        self.assertEqual(estimator.options.resilience_level, 0)
+        self.assertEqual(estimator.options.default_shots, 512)
+        self.assertEqual(
+            estimator.options.simulator.seed_simulator,
+            DEFAULT_RUNTIME_SEED,
+        )
+
+    def test_make_sampler_v2(self):
+        """Sampler helper wires deterministic options and optional default shots."""
+        backend, session, sampler = make_sampler_v2(
+            4, seed=DEFAULT_RUNTIME_SEED, default_shots=256
+        )
+        self.assertEqual(backend.num_qubits, 4)
+        self.assertIsNotNone(session)
+        self.assertEqual(sampler.options.simulator.seed_simulator, DEFAULT_RUNTIME_SEED)
+        self.assertEqual(sampler.options.default_shots, 256)


### PR DESCRIPTION
## Summary
- Add `test/utils/runtime_simulation.py` with shared helpers for deterministic local IBM Runtime tests
- Configure noise-free `GenericBackendV2` backends with fixed simulator, estimator, and transpiler seeds
- Migrate Runtime-backed tests called out in #903
- Add unit tests for the new helpers

## Root cause
Runtime-backed tests used `GenericBackendV2` without `noise_info=False`, so local simulation could include stochastic noise. Some tests also omitted fixed `seed_simulator` / `seed_transpiler` settings.

## Test plan
- [x] `test/utils/test_runtime_simulation.py`
- [x] `test_qbayesian.test_trivial_circuit_V2`
- [x] `test_estimator_gradient` Runtime gradient cases from #903
- [x] Flaky VQC runtime multiclass case run 3x locally — all passed

Fixes #903