### PR TITLE
Address "QNN warning seems out-of-place/unnecessary/different" #967

### DIFF
--- a/qiskit_machine_learning/neural_networks/estimator_qnn.py
+++ b/qiskit_machine_learning/neural_networks/estimator_qnn.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import logging
 from copy import copy
 from typing import Sequence
 
@@ -34,8 +33,6 @@ from ..gradients import (
     ParamShiftEstimatorGradient,
 )
 from .neural_network import NeuralNetwork
-
-logger = logging.getLogger(__name__)
 
 
 class EstimatorQNN(NeuralNetwork):
@@ -177,11 +174,6 @@ class EstimatorQNN(NeuralNetwork):
 
         # set gradient
         if gradient is None:
-            if pass_manager is None:
-                logger.warning(
-                    "No gradient function provided, creating a gradient function."
-                    " If your Estimator requires transpilation, please provide a pass manager."
-                )
             gradient = ParamShiftEstimatorGradient(
                 estimator=self.estimator, pass_manager=pass_manager
             )

--- a/qiskit_machine_learning/neural_networks/sampler_qnn.py
+++ b/qiskit_machine_learning/neural_networks/sampler_qnn.py
@@ -222,11 +222,6 @@ class SamplerQNN(NeuralNetwork):
 
         # Set gradient
         if gradient is None:
-            if pass_manager is None:
-                logger.warning(
-                    "No gradient function provided, creating a gradient function."
-                    " If your Sampler requires transpilation, please provide a pass manager."
-                )
             gradient = ParamShiftSamplerGradient(sampler=self.sampler, pass_manager=pass_manager)
         self.gradient = gradient
 


### PR DESCRIPTION
### Summary
Addresses #967. 
QNNs were reporting warnings when no gradient function was provided and they resorted to defaults. This is inconsistent with other algorithms and the wider code-base. Additionally, a transpiler warning was emitted, which again should not be reported at this level.

The result was that users could see warnings in situations where these warnings are not relevant (e.g., tutorials).

If users pass a primitive that requires transpilation, it should be their responsibility to provide associated pass manager. This is part of EstimatorQNN and SamplerQNN documentation. As such, the warnings should be removed.

### Details and comments
- Removed the warnings in `estimator_qnn.py` and `sampler_qnn.py`.
- While the change does not affect the code logic, tests were run and passed locally.