### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/apidocs/qiskit_machine_learning.primitives.rst
+++ b/docs/apidocs/qiskit_machine_learning.primitives.rst
@@ -26,7 +26,7 @@ Why introduce these wrappers?
 Qiskit's V2 primitives ecosystem standardizes execution around Primitive Unified Blocs (PUBs) and
 structured result objects. This infrastructure does not provide a direct way to compute the full
 statevector result without shot noise, which some unit tests and prototyping tasks benefit from.
-QML primitives address this needs by allowing the exact simulation mode directly, or acting as a
+QML primitives address this need by allowing the exact simulation mode directly, or acting as a
 light wrapper around Qiskit Statevector (V2) primitives when sampling with shot noise.
 
 Execution modes


### PR DESCRIPTION
### Summary

- "QML primitives address this needs by..." → "QML primitives address this need by..."

### Details and comments


