### PR TITLE
Fix ibm runtime issue caused by reparameterization

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -118,6 +118,7 @@ datasets
 deepcopy
 denoising
 deriv
+deserialization
 deterministically
 diag
 dicts

--- a/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
+++ b/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
@@ -138,7 +138,7 @@ class BaseStateFidelity(ABC):
         """
         raise NotImplementedError
 
-    def _check_param_name(self, param_name, circuit_param_names):
+    def _check_param_name(self, param_name: str, circuit_param_names: list[str]) -> str:
         """
         Check proposed parameter name is unique. This avoids a known parameter deserialization bug
         present in qiskit versions < 2.1.

--- a/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
+++ b/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
@@ -138,19 +138,6 @@ class BaseStateFidelity(ABC):
         """
         raise NotImplementedError
 
-    def _check_param_name(self, param_name: str, circuit_param_names: list[str]) -> str:
-        """
-        Check proposed parameter name is unique. This avoids a known parameter deserialization bug
-        present in qiskit versions < 2.1.
-        See https://github.com/Qiskit/qiskit/pull/13727 for more information.
-        """
-        i = 0
-        while any(name.startswith(f"{param_name}[") for name in circuit_param_names):
-            param_name = f"{param_name}_{i}"
-            i += 1
-
-        return param_name
-
     def _construct_circuits(
         self,
         circuits_1: QuantumCircuit | Sequence[QuantumCircuit],
@@ -198,19 +185,9 @@ class BaseStateFidelity(ABC):
                 # re-parametrize input circuits
                 # TODO: make smarter checks to avoid unnecessary re-parametrizations
 
-                circuit_param_names = [param.name for param in circuit_1.parameters] + [
-                    param.name for param in circuit_2.parameters
-                ]
-
-                param_1_name = "x_fidelity"
-                param_1_name = self._check_param_name(param_1_name, circuit_param_names)
-
-                param_2_name = "y_fidelity"
-                param_2_name = self._check_param_name(param_2_name, circuit_param_names)
-
-                parameters_1 = ParameterVector(param_1_name, circuit_1.num_parameters)
+                parameters_1 = ParameterVector("x_fidelity", circuit_1.num_parameters)
                 parametrized_circuit_1 = circuit_1.assign_parameters(parameters_1)
-                parameters_2 = ParameterVector(param_2_name, circuit_2.num_parameters)
+                parameters_2 = ParameterVector("y_fidelity", circuit_2.num_parameters)
                 parametrized_circuit_2 = circuit_2.assign_parameters(parameters_2)
 
                 circuit = self.create_fidelity_circuit(

--- a/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
+++ b/qiskit_machine_learning/state_fidelities/base_state_fidelity.py
@@ -138,6 +138,19 @@ class BaseStateFidelity(ABC):
         """
         raise NotImplementedError
 
+    def _check_param_name(self, param_name, circuit_param_names):
+        """
+        Check proposed parameter name is unique. This avoids a known parameter deserialization bug
+        present in qiskit versions < 2.1.
+        See https://github.com/Qiskit/qiskit/pull/13727 for more information.
+        """
+        i = 0
+        while any(name.startswith(f"{param_name}[") for name in circuit_param_names):
+            param_name = f"{param_name}_{i}"
+            i += 1
+
+        return param_name
+
     def _construct_circuits(
         self,
         circuits_1: QuantumCircuit | Sequence[QuantumCircuit],
@@ -184,9 +197,20 @@ class BaseStateFidelity(ABC):
 
                 # re-parametrize input circuits
                 # TODO: make smarter checks to avoid unnecessary re-parametrizations
-                parameters_1 = ParameterVector("x", circuit_1.num_parameters)
+
+                circuit_param_names = [param.name for param in circuit_1.parameters] + [
+                    param.name for param in circuit_2.parameters
+                ]
+
+                param_1_name = "x_fidelity"
+                param_1_name = self._check_param_name(param_1_name, circuit_param_names)
+
+                param_2_name = "y_fidelity"
+                param_2_name = self._check_param_name(param_2_name, circuit_param_names)
+
+                parameters_1 = ParameterVector(param_1_name, circuit_1.num_parameters)
                 parametrized_circuit_1 = circuit_1.assign_parameters(parameters_1)
-                parameters_2 = ParameterVector("y", circuit_2.num_parameters)
+                parameters_2 = ParameterVector(param_2_name, circuit_2.num_parameters)
                 parametrized_circuit_2 = circuit_2.assign_parameters(parameters_2)
 
                 circuit = self.create_fidelity_circuit(

--- a/qiskit_machine_learning/state_fidelities/compute_uncompute.py
+++ b/qiskit_machine_learning/state_fidelities/compute_uncompute.py
@@ -16,8 +16,11 @@ Compute-uncompute fidelity interface using primitives
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from copy import copy
+from collections.abc import Sequence
+
+from importlib.metadata import version
+from packaging.version import Version
 
 from qiskit import QuantumCircuit
 from qiskit.primitives import BaseSamplerV2, PrimitiveResult, SamplerPubResult
@@ -193,6 +196,24 @@ class ComputeUncompute(BaseStateFidelity):
         try:
             result = job.result()
         except Exception as exc:
+            message = str(exc)
+
+            backend = job.backend()
+            is_hardware = backend is not None and not backend.configuration().simulator
+
+            if (
+                "Cannot bind following parameters not present in expression" in message
+                and Version(version("qiskit")) < Version("2.2")
+                and is_hardware
+            ):
+                raise AlgorithmError(
+                    "Sampler job failed due to a circuit deserialization error. "
+                    "This could be caused by known issue. "
+                    "Ensure no circuit paramters are named x_fidelity or y_fidelity. "
+                    "For more information: "
+                    "https://github.com/qiskit-community/qiskit-machine-learning/pull/1060."
+                ) from exc
+
             raise AlgorithmError("Sampler job failed!") from exc
 
         quasi_dists = _post_process_v2(result, num_virtual_qubits)

--- a/qiskit_machine_learning/state_fidelities/compute_uncompute.py
+++ b/qiskit_machine_learning/state_fidelities/compute_uncompute.py
@@ -20,7 +20,6 @@ from copy import copy
 from collections.abc import Sequence
 
 from importlib.metadata import version
-from packaging.version import Version
 
 from qiskit import QuantumCircuit
 from qiskit.primitives import BaseSamplerV2, PrimitiveResult, SamplerPubResult
@@ -198,18 +197,17 @@ class ComputeUncompute(BaseStateFidelity):
         except Exception as exc:
             message = str(exc)
 
-            backend = job.backend()
-            is_hardware = backend is not None and not backend.configuration().simulator
+            is_hardware = getattr(job, "backend", None) is not None
 
             if (
                 "Cannot bind following parameters not present in expression" in message
-                and Version(version("qiskit")) < Version("2.2")
+                and (2, 0, 0) <= tuple(map(int, version("qiskit").split("."))) < (2, 2, 0)
                 and is_hardware
             ):
                 raise AlgorithmError(
                     "Sampler job failed due to a circuit deserialization error. "
-                    "This could be caused by known issue. "
-                    "Ensure no circuit paramters are named x_fidelity or y_fidelity. "
+                    "This could be caused by a known issue. "
+                    "Ensure no circuit parameters are named x_fidelity or y_fidelity. "
                     "For more information: "
                     "https://github.com/qiskit-community/qiskit-machine-learning/pull/1060."
                 ) from exc

--- a/test/state_fidelities/test_compute_uncompute.py
+++ b/test/state_fidelities/test_compute_uncompute.py
@@ -14,6 +14,7 @@
 """Tests for Fidelity."""
 
 import unittest
+from unittest.mock import Mock, patch
 from test import QiskitAlgorithmsTestCase
 
 import numpy as np
@@ -22,6 +23,7 @@ from qiskit.circuit.library import real_amplitudes
 
 from qiskit_machine_learning.state_fidelities import ComputeUncompute
 from qiskit_machine_learning.primitives import QMLSampler as Sampler
+from qiskit_machine_learning.exceptions import AlgorithmError
 
 
 class TestComputeUncompute(QiskitAlgorithmsTestCase):
@@ -216,6 +218,31 @@ class TestComputeUncompute(QiskitAlgorithmsTestCase):
         job = fidelity.run(circuit_1, circuit_2, self._left_params[0], self._right_params[0])
         result = job.result()
         np.testing.assert_allclose(result.fidelities, np.array([1.0]))
+
+    def test_job_failure_error_message(self):
+        """test job failure error message"""
+        cases = [
+            ("2.0.0", "Sampler job failed due to a circuit deserialization error"),
+            ("2.1.0", "Sampler job failed due to a circuit deserialization error"),
+            ("2.2.0", "Sampler job failed!"),
+        ]
+
+        job = Mock()
+        job.backend = Mock()
+        job.result.side_effect = Exception(
+            "Unable to retrieve job result. Error code 3211; Job not valid. "
+            "Circuit deserialization error. "
+            "Cannot bind following parameters not present in expression"
+        )
+
+        for qiskit_version, expected_msg in cases:
+            with self.subTest(qiskit_version=qiskit_version):
+                with patch(
+                    "qiskit_machine_learning.state_fidelities.compute_uncompute.version",
+                    return_value=qiskit_version,
+                ):
+                    with self.assertRaisesRegex(AlgorithmError, expected_msg):
+                        ComputeUncompute._call(job, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
PR related to #1042 
I tested the original PR https://github.com/qiskit-community/qiskit-machine-learning/pull/1045 fix and it did not work so I have created this new PR.

- Issue is resolved for Qiskit versions >= 2.2
- PR related to Qiskit fix: https://github.com/Qiskit/qiskit/pull/13727
- Issue occurs when a parameter name in reparameterisation is identical to the parameter name used in the original circuit
- This causes a runtime error: `RuntimeJobFailureError: 'Unable to retrieve job result. Error code 3211; Job not valid. Circuit deserialization error. \'Cannot bind following parameters not present in expression:`
- Fix involves changing reparameterization names from x and y to x_fidelity and y_fidelity

### Details and comments

Although the qiskit release containing the PR for the fix is included in version 2.1.0 the compatible ibm-runtime version 0.45.0 still causes the error and therefore (at least in my testing) it is only fixed for qiskit version >= 2.2 which is compatible with the working qiskit_ibm_runtime 0.46.0. Since qiskit-machine-learning is for qiskit >= 2.0 then this workaround is necassary.

- In #1042 the ZZFeatureMap creates a parameter vector with names `x[0], x[1]....`
- When we pass this into the `ComputeUncompute`/`BaseStateFidelity`,` BaseStateFidelity._construct_circuits` previously constructed `parameters_1 = ParameterVector("x", circuit_1.num_parameters)`  which would create the same names as the `ZZFeatureMap` thereby causing the issue.
- By renaming the reparameterized names in ` BaseStateFidelity._construct_circuits` from x and y to x_fidelity and y_fidelity we circumvent this issue however it is still possible for a user to recreate the error if they name a parameter x_fidelity or y_fidelity. 
- Due to this only being an issue for versions < 2.2 and it only occuring in the unlikely event that the parameters are named the same, the decision was made to not enforce that the names are unique since this would introduce unnecessary  computational cost.  Instead we provide a more descriptive error message that triggers under the specific conditions for the error.

I have verified the code works and the appropiate error messages appear for the given conditions using:
device: ibm_marrakesh device
qiskit: >= 2.0
qiskit_machine_learning: 1.0.0
qiskit_ibm_runtime: >= 0.45

**AI Disclosure** - *Minimal use of ChatGPT was used in this work. All code and checks were done by myself and AI was mainly used for research around what the error message meant and helped with finding the qiskit PR related to the fix.*

