### PR TITLE
Switched off the noise model in tests to avoid stochastic test failures.

### DIFF
--- a/test/gradients/test_estimator_gradient.py
+++ b/test/gradients/test_estimator_gradient.py
@@ -403,7 +403,7 @@ class TestEstimatorGradientRuntime(QiskitAlgorithmsTestCase):
     """Test Estimator Gradient for IBM Runtime"""
 
     def __init__(self, TestCase):
-        backend = GenericBackendV2(num_qubits=3, seed=123)
+        backend = GenericBackendV2(num_qubits=3, seed=123, noise_info=False)
         session = Session(backend=backend)
         simopts = SimulatorOptions(seed_simulator=123)
         estopts = EstimatorOptions(simulator=simopts)

--- a/test/gradients/test_sampler_gradient.py
+++ b/test/gradients/test_sampler_gradient.py
@@ -551,7 +551,7 @@ class TestSamplerGradientRuntime(QiskitAlgorithmsTestCase):
     """Test Sampler Gradient for IBM Runtime"""
 
     def __init__(self, TestCase):
-        backend = GenericBackendV2(num_qubits=3, seed=123)
+        backend = GenericBackendV2(num_qubits=3, seed=123, noise_info=False)
         session = Session(backend=backend)
         self.sampler = SamplerV2(mode=session)
         self.pass_manager = generate_preset_pass_manager(optimization_level=1, backend=backend)

--- a/test/neural_networks/test_estimator_qnn.py
+++ b/test/neural_networks/test_estimator_qnn.py
@@ -180,7 +180,7 @@ class TestEstimatorQNNV2(QiskitMachineLearningTestCase):
     """EstimatorQNN Tests for estimator_v2. The correct references is obtained from EstimatorQNN"""
 
     tolerance: dict[str, float] = dict(atol=3 * 1.0e-1, rtol=3 * 1.0e-1)
-    backend = GenericBackendV2(num_qubits=2, seed=123)
+    backend = GenericBackendV2(num_qubits=2, seed=123, noise_info=False)
     session = Session(backend=backend)
 
     def __init__(

--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -104,7 +104,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
         # define sampler primitives
         self.sampler = Sampler()
         self.sampler_shots = Sampler(default_shots=100, seed=42)
-        self.backend = GenericBackendV2(num_qubits=8)
+        self.backend = GenericBackendV2(num_qubits=8, seed=123, noise_info=False)
         self.session = Session(backend=self.backend)
         self.sampler_v2 = SamplerV2(mode=self.session)
         self.pass_manager = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Resolves #903
While most of the tests have noise model switched off, tests on gradients and neural networks (using sampler and estimator) didn't set the noise model parameter, which defaulted to being on, resulting in random CI failures.


### Details and comments
- added `noise_info=False` parameter when instantiating `GenericBackendV2` objects. This is in line with other test cases.
- tested locally and all tests pass, however this will need to be verified with CI, which will run after opening this PR.
- No AI has been used in the preparation of this commit, code or PR.


