### PR TITLE
Fix: Types errors with new version of mypy

### DIFF
--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -144,7 +144,7 @@ class NeuralNetwork(ABC):
             input_ = input_.reshape((1, -1))
         elif len(shape) > 2:
             # flatten lower dimensions, keep num_inputs as a last dimension
-            input_ = input_.reshape((np.prod(input_.shape[:-1]), -1))
+            input_ = input_.reshape((int(np.prod(input_.shape[:-1])), -1))
 
         return input_, shape
 

--- a/qiskit_machine_learning/optimizers/aqgd.py
+++ b/qiskit_machine_learning/optimizers/aqgd.py
@@ -236,7 +236,7 @@ class AQGD(Optimizer):
         # Calculate previous windowed average
         # and current windowed average of objective values
         prev_avg = np.mean(self._prev_loss[:window_size])
-        curr_avg = np.mean(self._prev_loss[1 : window_size + 1])
+        curr_avg = float(np.mean(self._prev_loss[1 : window_size + 1]))
         self._avg_objval = curr_avg
 
         # Update window of objective values

--- a/qiskit_machine_learning/optimizers/aqgd.py
+++ b/qiskit_machine_learning/optimizers/aqgd.py
@@ -237,7 +237,7 @@ class AQGD(Optimizer):
         # and current windowed average of objective values
         prev_avg = np.mean(self._prev_loss[:window_size])
         curr_avg = np.mean(self._prev_loss[1 : window_size + 1])
-        self._avg_objval = curr_avg  # type: ignore[assignment]
+        self._avg_objval = curr_avg
 
         # Update window of objective values
         # (Remove earliest value)

--- a/qiskit_machine_learning/optimizers/gradient_descent.py
+++ b/qiskit_machine_learning/optimizers/gradient_descent.py
@@ -324,7 +324,7 @@ class GradientDescent(SteppableOptimizer):
             raise ValueError("The gradient does not have the correct dimension")
         # pylint: disable=attribute-defined-outside-init
         self.state.x = self.state.x - next(self.state.learning_rate) * tell_data.eval_jac
-        self.state.stepsize = np.linalg.norm(tell_data.eval_jac)  # type: ignore[arg-type, assignment]
+        self.state.stepsize = np.linalg.norm(tell_data.eval_jac)  # type: ignore[arg-type]
         self.state.nit += 1
 
     def evaluate(self, ask_data: AskData) -> TellData:

--- a/qiskit_machine_learning/optimizers/gradient_descent.py
+++ b/qiskit_machine_learning/optimizers/gradient_descent.py
@@ -324,7 +324,7 @@ class GradientDescent(SteppableOptimizer):
             raise ValueError("The gradient does not have the correct dimension")
         # pylint: disable=attribute-defined-outside-init
         self.state.x = self.state.x - next(self.state.learning_rate) * tell_data.eval_jac
-        self.state.stepsize = np.linalg.norm(tell_data.eval_jac)  # type: ignore[arg-type]
+        self.state.stepsize = float(np.linalg.norm(tell_data.eval_jac))  # type: ignore[arg-type]
         self.state.nit += 1
 
     def evaluate(self, ask_data: AskData) -> TellData:

--- a/qiskit_machine_learning/primitives/sampler.py
+++ b/qiskit_machine_learning/primitives/sampler.py
@@ -364,7 +364,7 @@ class ExactProbNDArray:
         ExactProbArray."""
         for raw in self._arr.flat:
             if isinstance(raw, ExactProbArray):
-                rep = cast(ExactProbArray, raw)
+                rep = raw
                 return rep.num_bits
         return 0
 

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -105,7 +105,9 @@ class L1Loss(Loss):
         if len(predict.shape) <= 1:
             return np.abs(predict - target)
         else:
-            return np.linalg.norm(predict - target, ord=1, axis=tuple(range(1, len(predict.shape))))
+            diff = predict - target
+            diff = diff.reshape(diff.shape[0], -1)
+            return np.linalg.norm(diff, ord=1, axis=1)
 
     def gradient(self, predict: np.ndarray, target: np.ndarray) -> np.ndarray:
         self._validate_shapes(predict, target)
@@ -129,7 +131,9 @@ class L2Loss(Loss):
         if len(predict.shape) <= 1:
             return (predict - target) ** 2
         else:
-            return np.linalg.norm(predict - target, axis=tuple(range(1, len(predict.shape)))) ** 2
+            diff = predict - target
+            diff = diff.reshape(diff.shape[0], -1)
+            return np.linalg.norm(diff, axis=1) ** 2
 
     def gradient(self, predict: np.ndarray, target: np.ndarray) -> np.ndarray:
         self._validate_shapes(predict, target)

--- a/test/gradients/test_estimator_gradient.py
+++ b/test/gradients/test_estimator_gradient.py
@@ -403,7 +403,7 @@ class TestEstimatorGradientRuntime(QiskitAlgorithmsTestCase):
     """Test Estimator Gradient for IBM Runtime"""
 
     def __init__(self, TestCase):
-        backend = GenericBackendV2(num_qubits=3, seed=123)
+        backend = GenericBackendV2(num_qubits=3, seed=123, noise_info=False)
         session = Session(backend=backend)
         simopts = SimulatorOptions(seed_simulator=123)
         estopts = EstimatorOptions(simulator=simopts)

--- a/test/gradients/test_sampler_gradient.py
+++ b/test/gradients/test_sampler_gradient.py
@@ -551,7 +551,7 @@ class TestSamplerGradientRuntime(QiskitAlgorithmsTestCase):
     """Test Sampler Gradient for IBM Runtime"""
 
     def __init__(self, TestCase):
-        backend = GenericBackendV2(num_qubits=3, seed=123)
+        backend = GenericBackendV2(num_qubits=3, seed=123, noise_info=False)
         session = Session(backend=backend)
         self.sampler = SamplerV2(mode=session)
         self.pass_manager = generate_preset_pass_manager(optimization_level=1, backend=backend)

--- a/test/neural_networks/test_estimator_qnn.py
+++ b/test/neural_networks/test_estimator_qnn.py
@@ -180,7 +180,7 @@ class TestEstimatorQNNV2(QiskitMachineLearningTestCase):
     """EstimatorQNN Tests for estimator_v2. The correct references is obtained from EstimatorQNN"""
 
     tolerance: dict[str, float] = dict(atol=3 * 1.0e-1, rtol=3 * 1.0e-1)
-    backend = GenericBackendV2(num_qubits=2, seed=123)
+    backend = GenericBackendV2(num_qubits=2, seed=123, noise_info=False)
     session = Session(backend=backend)
 
     def __init__(

--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -104,7 +104,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
         # define sampler primitives
         self.sampler = Sampler()
         self.sampler_shots = Sampler(default_shots=100, seed=42)
-        self.backend = GenericBackendV2(num_qubits=8)
+        self.backend = GenericBackendV2(num_qubits=8, seed=123, noise_info=False)
         self.session = Session(backend=self.backend)
         self.sampler_v2 = SamplerV2(mode=self.session)
         self.pass_manager = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Resolves #1062 
As per the issue, new version of mypy highlighted couple of type errors. This PR fixes them.

### Details and comments
- Removed redundant casts and type ignore comments
- Added missing cast
- Implementation of L1 and L2 was incorrect in that it was passing unbounded tuple to `axis` parameter in `np.linalg.norm` (which expects `None|int|2-tuple`). Re-implemented both functions by taking the difference of `prediction` and `target`, and flattening it before passing to `numpy` function.
- Run `make mypy` and tests locally (python3.12)
