### PR TITLE
Feat - Pegasos Quantum Kernel Alignment

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -473,6 +473,7 @@ qgts
 qinds
 qiskit
 qiskit's
+qka
 qml
 qn
 qnn

--- a/qiskit_machine_learning/algorithms/__init__.py
+++ b/qiskit_machine_learning/algorithms/__init__.py
@@ -88,7 +88,7 @@ from .objective_functions import (
     MultiClassObjectiveFunction,
     OneHotObjectiveFunction,
 )
-from .classifiers import QSVC, PegasosQSVC, VQC, NeuralNetworkClassifier
+from .classifiers import QSVC, PegasosQSVC, PegasosQKA, VQC, NeuralNetworkClassifier
 from .inference import QBayesian
 from .regressors import QSVR, VQR, NeuralNetworkRegressor
 
@@ -101,6 +101,7 @@ __all__ = [
     "OneHotObjectiveFunction",
     "QSVC",
     "PegasosQSVC",
+    "PegasosQKA",
     "NeuralNetworkClassifier",
     "VQC",
     "QSVR",

--- a/qiskit_machine_learning/algorithms/classifiers/__init__.py
+++ b/qiskit_machine_learning/algorithms/classifiers/__init__.py
@@ -15,7 +15,8 @@
 
 from .neural_network_classifier import NeuralNetworkClassifier
 from .pegasos_qsvc import PegasosQSVC
+from .pegasos_qka import PegasosQKA
 from .qsvc import QSVC
 from .vqc import VQC
 
-__all__ = ["NeuralNetworkClassifier", "QSVC", "PegasosQSVC", "VQC"]
+__all__ = ["NeuralNetworkClassifier", "QSVC", "PegasosQSVC", "PegasosQKA", "VQC"]

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qka.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qka.py
@@ -1,0 +1,136 @@
+"""Pegasos Quantum Kernel Alignment algorithm."""
+from typing import Optional, Tuple, Union, Iterator
+
+import numpy as np
+from ...optimizers.spsa import bernoulli_perturbation
+from .pegasos_qsvc import PegasosQSVC
+
+
+class PegasosQKA(PegasosQSVC):
+    r"""
+    Extends the Pegasos Quantum Support Vector Classifier algorithm to perform quantum 
+    kernel alignment within the optimization loop. The algorithm has been developed in [1]. 
+    This implementation is adapted to work with trainable quantum kernels.
+
+    **Example**
+
+    .. code-block:: python
+
+        quantum_kernel = TrainableFidelityQuantumKernel()
+
+        pegasos_qka = PegasosQKA(quantum_kernel=quantum_kernel)
+        pegasos_qka.fit(sample_train, label_train)
+        pegasos_qka.predict(sample_test)
+
+    **References**
+        [1]: G. Gentinetta, D. Sutter, C. Zoufal, B. Fuller and S. Woerner, 
+        Quantum Kernel Alignment with Stochastic Gradient Descent 
+        <https://ieeexplore.ieee.org/document/10313634>`_
+
+    """
+     
+    def __init__(
+        self,
+        quantum_kernel=None,
+        C: float = 1000.0,
+        num_steps: Optional[int] = None,
+        seed: Optional[int] = None,
+        initial_thetas: Optional[np.ndarray] = None,
+        learning_rate: float = 0.01,
+        perturbations: float = 0.01,
+    ) -> None:
+        super().__init__(
+            quantum_kernel=quantum_kernel,
+            C=C,
+            num_steps=num_steps,
+            seed=seed,
+        )
+
+        if initial_thetas is None:
+            self._theta = np.zeros(quantum_kernel.num_training_parameters)
+        else:
+            if len(initial_thetas) == quantum_kernel.num_training_parameters:
+                self._theta = np.atleast_1d(initial_thetas)
+            else:
+                raise ValueError(
+                    f"Number of parameters in initial guess ({len(initial_thetas)}) does not match"
+                    f"number of parameters in Kernel ({quantum_kernel.num_training_parameters})."
+                )
+
+        self._support_thetas = {}
+        self._left_theta = self._theta.copy()
+        self.learning_rate = learning_rate
+        self.perturbations = perturbations
+
+    def _update_step(self, index: int, X: np.ndarray, y: np.ndarray, step: int) -> None:
+        """
+        Implements an update step for the fit method.
+        
+        Args:
+            index: Index of the selected training sample.
+            X: Training features.
+            y: Training labels.
+            step: Current training step.
+        """
+        value = self._compute_weighted_kernel_sum(index, X, training=True)
+
+        y_step = self._label_map[y[index]]
+
+        new_theta = self._theta
+        support_theta=new_theta.copy()
+
+        if (y_step * self.C / step) * value < 1:
+  
+            # choose update direction
+            n = bernoulli_perturbation(self._quantum_kernel.num_training_parameters)
+
+            # approximate gradient in that direction
+            factor = y_step * self.C / step
+            theta_plus = new_theta + self.perturbations * n
+            theta_minus = new_theta - self.perturbations * n
+            self._left_theta = theta_plus
+            obj_plus = -factor * self._compute_weighted_kernel_sum(index, X, training=True)
+            self._left_theta = theta_minus
+            obj_minus = -factor * self._compute_weighted_kernel_sum(index, X, training=True)
+
+            gradient = (obj_plus - obj_minus) / (2 * self.perturbations) if self.perturbations > 0 else 0
+
+            new_theta = (new_theta - self.learning_rate * gradient * n).flatten()
+
+            # update alpha & theta
+            self._alphas[index] = self._alphas.get(index, 0) + 1
+            if index not in self._support_thetas:
+                self._support_thetas[index] = []
+
+            self._support_thetas[index].append(support_theta)
+            
+        self._theta = new_theta
+        self._left_theta = new_theta
+    
+    def _evaluate_kernel(self, x: np.ndarray, x_supp: np.ndarray, support_indices: list[int]) -> np.ndarray:
+        """
+        Evaluate the paramaterized kernel function for a single data point and the support vectors.
+
+        For each support vector, evaluate the kernel using the current parameters
+        on the left and for each parameter snapshot associated with that support vector on the right. 
+        The resulting kernel values are averaged over the parameter snapshots.
+
+        Args:
+            x: Data point to evaluate.
+            x_supp: Support vectors.
+            support_indices: Training data indices corresponding to the support vectors x_supp.
+
+        Returns:
+            Kernel values between the data point and support vectors.
+        """
+
+        values = []
+        for x_right, index in zip(x_supp, support_indices):
+            kernels = []
+            for right_theta in self._support_thetas[index]:
+                kernel = self._quantum_kernel.evaluate(x, x_right, self._left_theta, right_theta) + self._kernel_offset
+                kernels.append(kernel)
+            values.append(np.mean(kernels))
+
+        return np.asarray(values)
+

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qka.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qka.py
@@ -38,15 +38,16 @@ class PegasosQKA(PegasosQSVC):
         pegasos_qka.predict(sample_test)
 
     **References**
-        [1]: G. Gentinetta, D. Sutter, C. Zoufal, B. Fuller and S. Woerner,
-        Quantum Kernel Alignment with Stochastic Gradient Descent
+        [1]: Quantum Kernel Alignment with Stochastic Gradient Descent
         <https://ieeexplore.ieee.org/document/10313634>`_
 
     """
 
     def __init__(
         self,
-        quantum_kernel=TrainableFidelityQuantumKernel | TrainableFidelityStatevectorKernel,
+        quantum_kernel: (
+            TrainableFidelityQuantumKernel | TrainableFidelityStatevectorKernel | None
+        ) = None,
         C: float = 1000.0,
         num_steps: Optional[int] = None,
         seed: Optional[int] = None,
@@ -74,7 +75,7 @@ class PegasosQKA(PegasosQSVC):
                 )
 
         self._quantum_kernel: (
-            TrainableFidelityQuantumKernel | TrainableFidelityStatevectorKernel
+            TrainableFidelityQuantumKernel | TrainableFidelityStatevectorKernel | None
         ) = quantum_kernel
         self._support_thetas: dict[int, list[np.ndarray]] = {}
         self._left_theta = self._theta.copy()

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qka.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qka.py
@@ -1,15 +1,30 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """Pegasos Quantum Kernel Alignment algorithm."""
-from typing import Optional, Tuple, Union, Iterator
+
+from typing import Optional
 
 import numpy as np
+from ...kernels import TrainableFidelityQuantumKernel, TrainableFidelityStatevectorKernel
 from ...optimizers.spsa import bernoulli_perturbation
 from .pegasos_qsvc import PegasosQSVC
 
 
 class PegasosQKA(PegasosQSVC):
     r"""
-    Extends the Pegasos Quantum Support Vector Classifier algorithm to perform quantum 
-    kernel alignment within the optimization loop. The algorithm has been developed in [1]. 
+    Extends the Pegasos Quantum Support Vector Classifier algorithm to perform quantum
+    kernel alignment within the optimization loop. The algorithm has been developed in [1].
     This implementation is adapted to work with trainable quantum kernels.
 
     **Example**
@@ -23,18 +38,19 @@ class PegasosQKA(PegasosQSVC):
         pegasos_qka.predict(sample_test)
 
     **References**
-        [1]: G. Gentinetta, D. Sutter, C. Zoufal, B. Fuller and S. Woerner, 
-        Quantum Kernel Alignment with Stochastic Gradient Descent 
+        [1]: G. Gentinetta, D. Sutter, C. Zoufal, B. Fuller and S. Woerner,
+        Quantum Kernel Alignment with Stochastic Gradient Descent
         <https://ieeexplore.ieee.org/document/10313634>`_
 
     """
-     
+
     def __init__(
         self,
-        quantum_kernel=None,
+        quantum_kernel=TrainableFidelityQuantumKernel | TrainableFidelityStatevectorKernel,
         C: float = 1000.0,
         num_steps: Optional[int] = None,
         seed: Optional[int] = None,
+        *,
         initial_thetas: Optional[np.ndarray] = None,
         learning_rate: float = 0.01,
         perturbations: float = 0.01,
@@ -57,7 +73,10 @@ class PegasosQKA(PegasosQSVC):
                     f"number of parameters in Kernel ({quantum_kernel.num_training_parameters})."
                 )
 
-        self._support_thetas = {}
+        self._quantum_kernel: (
+            TrainableFidelityQuantumKernel | TrainableFidelityStatevectorKernel
+        ) = quantum_kernel
+        self._support_thetas: dict[int, list[np.ndarray]] = {}
         self._left_theta = self._theta.copy()
         self.learning_rate = learning_rate
         self.perturbations = perturbations
@@ -65,7 +84,7 @@ class PegasosQKA(PegasosQSVC):
     def _update_step(self, index: int, X: np.ndarray, y: np.ndarray, step: int) -> None:
         """
         Implements an update step for the fit method.
-        
+
         Args:
             index: Index of the selected training sample.
             X: Training features.
@@ -77,10 +96,10 @@ class PegasosQKA(PegasosQSVC):
         y_step = self._label_map[y[index]]
 
         new_theta = self._theta
-        support_theta=new_theta.copy()
+        support_theta = new_theta.copy()
 
         if (y_step * self.C / step) * value < 1:
-  
+
             # choose update direction
             n = bernoulli_perturbation(self._quantum_kernel.num_training_parameters)
 
@@ -93,7 +112,9 @@ class PegasosQKA(PegasosQSVC):
             self._left_theta = theta_minus
             obj_minus = -factor * self._compute_weighted_kernel_sum(index, X, training=True)
 
-            gradient = (obj_plus - obj_minus) / (2 * self.perturbations) if self.perturbations > 0 else 0
+            gradient = (
+                (obj_plus - obj_minus) / (2 * self.perturbations) if self.perturbations > 0 else 0
+            )
 
             new_theta = (new_theta - self.learning_rate * gradient * n).flatten()
 
@@ -103,16 +124,18 @@ class PegasosQKA(PegasosQSVC):
                 self._support_thetas[index] = []
 
             self._support_thetas[index].append(support_theta)
-            
+
         self._theta = new_theta
         self._left_theta = new_theta
-    
-    def _evaluate_kernel(self, x: np.ndarray, x_supp: np.ndarray, support_indices: list[int]) -> np.ndarray:
+
+    def _evaluate_kernel(
+        self, x: np.ndarray, x_supp: np.ndarray, support_indices: list[int]
+    ) -> np.ndarray:
         """
-        Evaluate the paramaterized kernel function for a single data point and the support vectors.
+        Evaluate the parameterized kernel function for a single data point and the support vectors.
 
         For each support vector, evaluate the kernel using the current parameters
-        on the left and for each parameter snapshot associated with that support vector on the right. 
+        on the left and for each parameter snapshot associated with that support vector on the right.
         The resulting kernel values are averaged over the parameter snapshots.
 
         Args:
@@ -128,9 +151,11 @@ class PegasosQKA(PegasosQSVC):
         for x_right, index in zip(x_supp, support_indices):
             kernels = []
             for right_theta in self._support_thetas[index]:
-                kernel = self._quantum_kernel.evaluate(x, x_right, self._left_theta, right_theta) + self._kernel_offset
+                kernel = (
+                    self._quantum_kernel.evaluate(x, x_right, self._left_theta, right_theta)
+                    + self._kernel_offset
+                )
                 kernels.append(kernel)
             values.append(np.mean(kernels))
 
         return np.asarray(values)
-

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
@@ -189,18 +189,31 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
         for step in range(1, self._num_steps + 1):
             # for every step, a random index (determining a random datum) is fixed
             i = int(algorithm_globals.random.integers(0, len(y)))
-
-            value = self._compute_weighted_kernel_sum(i, X, training=True)
-
-            if (self._label_map[y[i]] * self.C / step) * value < 1:
-                # only way for a component of alpha to become non zero
-                self._alphas[i] = self._alphas.get(i, 0) + 1
+            self._update_step(i, X, y, step)
+            
 
         self.fit_status_ = PegasosQSVC.FITTED
 
         logger.debug("Fit completed after %s", str(datetime.now() - t_0)[:-7])
 
         return self
+
+    def _update_step(self, index: int, X: np.ndarray, y: np.ndarray, step: int) -> None:
+        """
+        Implements an update step for the fit method.
+        
+        Args:
+            index: Index of the selected training sample.
+            X: Training features.
+            y: Training labels.
+            step: Current training step.
+        """
+        value = self._compute_weighted_kernel_sum(index, X, training=True)
+        
+        if (self._label_map[y[index]] * self.C / step) * value < 1:
+            # only way for a component of alpha to become non zero
+            self._alphas[index] = self._alphas.get(index, 0) + 1
+
 
     # pylint: disable=invalid-name
     def predict(self, X: np.ndarray) -> np.ndarray:
@@ -297,6 +310,26 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
 
         return values
 
+    def _evaluate_kernel(self, x: np.ndarray, x_supp: np.ndarray, support_indices: list[int]) -> np.ndarray:
+        """
+        Evaluate the kernel function for a single data point and the support vectors.
+
+        Args:
+            x: Data point to evaluate.
+            x_supp: Support vectors.
+            support_indices: Training data indices corresponding to the support vectors x_supp.
+
+        Returns:
+            Kernel values between the data point and support vectors.
+        """
+
+        if not self._precomputed:
+            kernel = self._quantum_kernel.evaluate(x, x_supp) + self._kernel_offset
+        else:
+            kernel = x[support_indices]
+
+        return kernel
+
     def _compute_weighted_kernel_sum(self, index: int, X: np.ndarray, training: bool) -> float:
         """Helper function to compute the weighted sum over support vectors used for both training
         and prediction with the Pegasos algorithm.
@@ -319,11 +352,8 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
         # for prediction
         else:
             x_supp = self._x_train[support_indices]
-        if not self._precomputed:
-            # evaluate kernel function only for the fixed datum and the support vectors
-            kernel = self._quantum_kernel.evaluate(X[index], x_supp) + self._kernel_offset
-        else:
-            kernel = X[index, support_indices]
+
+        kernel = self._evaluate_kernel(X[index], x_supp, support_indices)
 
         # map the training labels of the support vectors to {-1,1}
         y = np.array(list(map(self._label_map.get, self._y_train[support_indices])))

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
@@ -190,7 +190,6 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
             # for every step, a random index (determining a random datum) is fixed
             i = int(algorithm_globals.random.integers(0, len(y)))
             self._update_step(i, X, y, step)
-            
 
         self.fit_status_ = PegasosQSVC.FITTED
 
@@ -201,7 +200,7 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
     def _update_step(self, index: int, X: np.ndarray, y: np.ndarray, step: int) -> None:
         """
         Implements an update step for the fit method.
-        
+
         Args:
             index: Index of the selected training sample.
             X: Training features.
@@ -209,11 +208,10 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
             step: Current training step.
         """
         value = self._compute_weighted_kernel_sum(index, X, training=True)
-        
+
         if (self._label_map[y[index]] * self.C / step) * value < 1:
             # only way for a component of alpha to become non zero
             self._alphas[index] = self._alphas.get(index, 0) + 1
-
 
     # pylint: disable=invalid-name
     def predict(self, X: np.ndarray) -> np.ndarray:
@@ -310,7 +308,9 @@ class PegasosQSVC(ClassifierMixin, SerializableModelMixin):
 
         return values
 
-    def _evaluate_kernel(self, x: np.ndarray, x_supp: np.ndarray, support_indices: list[int]) -> np.ndarray:
+    def _evaluate_kernel(
+        self, x: np.ndarray, x_supp: np.ndarray, support_indices: list[int]
+    ) -> np.ndarray:
         """
         Evaluate the kernel function for a single data point and the support vectors.
 

--- a/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
@@ -37,11 +37,12 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
     map, which can be used to fine-tune the kernel.
 
     This kernel has trainable parameters :math:`\theta` that can be bound using training algorithms.
+    Different parameter values may be used for the left and right feature maps.
     The kernel entries are given as
 
     .. math::
 
-        K_{\theta}(x,y) = |\langle \phi_{\theta}(x) | \phi_{\theta}(y) \rangle|^2
+        K_{\theta_x,\theta_y}(x,y) = |\langle \phi_{\theta_x}(x) | \phi_{\theta_y}(y) \rangle|^2
     """
 
     def __init__(
@@ -102,16 +103,70 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
         self._parameter_dict = {parameter: None for parameter in self.feature_map.parameters}
 
     def _get_parameterization(
-        self, x_vec: np.ndarray, y_vec: np.ndarray
+        self, 
+        x_vec: np.ndarray, 
+        y_vec: np.ndarray, 
+        x_parameters: np.ndarray | None = None, 
+        y_parameters: np.ndarray | None = None
     ) -> tuple[np.ndarray, np.ndarray, KernelIndices]:
-        new_x_vec = self._parameter_array(x_vec)
-        new_y_vec = self._parameter_array(y_vec)
+        new_x_vec = self._parameter_array(x_vec, x_parameters)
+        new_y_vec = self._parameter_array(y_vec, y_parameters)
 
         return super()._get_parameterization(new_x_vec, new_y_vec)
 
+
     def _get_symmetric_parameterization(
-        self, x_vec: np.ndarray
+        self, x_vec: np.ndarray, x_parameters: np.ndarray | None = None
     ) -> tuple[np.ndarray, np.ndarray, KernelIndices]:
-        new_x_vec = self._parameter_array(x_vec)
+        new_x_vec = self._parameter_array(x_vec, x_parameters)
 
         return super()._get_symmetric_parameterization(new_x_vec)
+
+    def evaluate(
+        self, 
+        x_vec: np.ndarray, 
+        y_vec: np.ndarray | None = None, 
+        x_parameters: np.ndarray | None = None, 
+        y_parameters: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """
+        Evaluate the kernel matrix.
+
+        Args:
+            x_vec: Input data for the left feature map.
+            y_vec: Input data for the right feature map.
+            x_parameters: Training parameter values for the left feature map.
+            y_parameters: Training parameter values for the right feature map.
+
+        Returns:
+            The evaluated kernel matrix.
+        """
+        x_vec, y_vec = self._validate_input(x_vec, y_vec)
+
+        # determine if calculating self inner product
+        if y_vec is None:
+            y_vec = x_vec
+
+        x_parameter_values = self.parameter_values if x_parameters is None else x_parameters
+        y_parameter_values = self.parameter_values if y_parameters is None else y_parameters
+
+        is_symmetric = np.array_equal(x_vec, y_vec) and np.array_equal(x_parameter_values, y_parameter_values)
+
+        kernel_shape = (x_vec.shape[0], y_vec.shape[0])
+
+        if is_symmetric:
+            left_parameters, right_parameters, indices = self._get_symmetric_parameterization(x_vec, x_parameters)
+            kernel_matrix = self._get_symmetric_kernel_matrix(
+                kernel_shape, left_parameters, right_parameters, indices
+            )
+        else:
+            left_parameters, right_parameters, indices = self._get_parameterization(x_vec, y_vec, x_parameters, y_parameters)
+            kernel_matrix = self._get_kernel_matrix(
+                kernel_shape, left_parameters, right_parameters, indices
+            )
+
+        if is_symmetric and self._enforce_psd:
+            kernel_matrix = self._make_psd(kernel_matrix)
+
+        return kernel_matrix
+

--- a/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_quantum_kernel.py
@@ -103,17 +103,16 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
         self._parameter_dict = {parameter: None for parameter in self.feature_map.parameters}
 
     def _get_parameterization(
-        self, 
-        x_vec: np.ndarray, 
-        y_vec: np.ndarray, 
-        x_parameters: np.ndarray | None = None, 
-        y_parameters: np.ndarray | None = None
+        self,
+        x_vec: np.ndarray,
+        y_vec: np.ndarray,
+        x_parameters: np.ndarray | None = None,
+        y_parameters: np.ndarray | None = None,
     ) -> tuple[np.ndarray, np.ndarray, KernelIndices]:
         new_x_vec = self._parameter_array(x_vec, x_parameters)
         new_y_vec = self._parameter_array(y_vec, y_parameters)
 
         return super()._get_parameterization(new_x_vec, new_y_vec)
-
 
     def _get_symmetric_parameterization(
         self, x_vec: np.ndarray, x_parameters: np.ndarray | None = None
@@ -123,10 +122,10 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
         return super()._get_symmetric_parameterization(new_x_vec)
 
     def evaluate(
-        self, 
-        x_vec: np.ndarray, 
-        y_vec: np.ndarray | None = None, 
-        x_parameters: np.ndarray | None = None, 
+        self,
+        x_vec: np.ndarray,
+        y_vec: np.ndarray | None = None,
+        x_parameters: np.ndarray | None = None,
         y_parameters: np.ndarray | None = None,
     ) -> np.ndarray:
         """
@@ -150,17 +149,23 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
         x_parameter_values = self.parameter_values if x_parameters is None else x_parameters
         y_parameter_values = self.parameter_values if y_parameters is None else y_parameters
 
-        is_symmetric = np.array_equal(x_vec, y_vec) and np.array_equal(x_parameter_values, y_parameter_values)
+        is_symmetric = np.array_equal(x_vec, y_vec) and np.array_equal(
+            x_parameter_values, y_parameter_values
+        )
 
         kernel_shape = (x_vec.shape[0], y_vec.shape[0])
 
         if is_symmetric:
-            left_parameters, right_parameters, indices = self._get_symmetric_parameterization(x_vec, x_parameters)
+            left_parameters, right_parameters, indices = self._get_symmetric_parameterization(
+                x_vec, x_parameters
+            )
             kernel_matrix = self._get_symmetric_kernel_matrix(
                 kernel_shape, left_parameters, right_parameters, indices
             )
         else:
-            left_parameters, right_parameters, indices = self._get_parameterization(x_vec, y_vec, x_parameters, y_parameters)
+            left_parameters, right_parameters, indices = self._get_parameterization(
+                x_vec, y_vec, x_parameters, y_parameters
+            )
             kernel_matrix = self._get_kernel_matrix(
                 kernel_shape, left_parameters, right_parameters, indices
             )
@@ -169,4 +174,3 @@ class TrainableFidelityQuantumKernel(TrainableKernel, FidelityQuantumKernel):
             kernel_matrix = self._make_psd(kernel_matrix)
 
         return kernel_matrix
-

--- a/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
@@ -99,23 +99,23 @@ class TrainableFidelityStatevectorKernel(TrainableKernel, FidelityStatevectorKer
         self._parameter_dict = {parameter: None for parameter in self.feature_map.parameters}
 
     def _evaluate(
-            self, 
-            x_vec: np.ndarray, 
-            y_vec: np.ndarray, 
-            is_symmetric: bool, 
-            x_parameters: np.ndarray | None = None, 
-            y_parameters: np.ndarray | None = None
+        self,
+        x_vec: np.ndarray,
+        y_vec: np.ndarray,
+        is_symmetric: bool,
+        x_parameters: np.ndarray | None = None,
+        y_parameters: np.ndarray | None = None,
     ):
         new_x_vec = self._parameter_array(x_vec, x_parameters)
         new_y_vec = self._parameter_array(y_vec, y_parameters)
         return super()._evaluate(new_x_vec, new_y_vec, is_symmetric)
 
     def evaluate(
-            self, 
-            x_vec: np.ndarray, 
-            y_vec: np.ndarray | None = None,
-            x_parameters: np.ndarray | None = None, 
-            y_parameters: np.ndarray | None = None,
+        self,
+        x_vec: np.ndarray,
+        y_vec: np.ndarray | None = None,
+        x_parameters: np.ndarray | None = None,
+        y_parameters: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Evaluate the kernel matrix.
@@ -141,7 +141,9 @@ class TrainableFidelityStatevectorKernel(TrainableKernel, FidelityStatevectorKer
         x_parameter_values = self.parameter_values if x_parameters is None else x_parameters
         y_parameter_values = self.parameter_values if y_parameters is None else y_parameters
 
-        is_symmetric = np.array_equal(x_vec, y_vec) and np.array_equal(x_parameter_values, y_parameter_values)
+        is_symmetric = np.array_equal(x_vec, y_vec) and np.array_equal(
+            x_parameter_values, y_parameter_values
+        )
 
         return self._evaluate(
             x_vec,

--- a/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_fidelity_statevector_kernel.py
@@ -37,11 +37,12 @@ class TrainableFidelityStatevectorKernel(TrainableKernel, FidelityStatevectorKer
     map, which can be used to fine-tune the kernel.
 
     This kernel has trainable parameters :math:`\theta` that can be bound using training algorithms.
+    Different parameter values may be used for the left and right feature maps.
     The kernel entries are given as
 
     .. math::
 
-        K_{\theta}(x,y) = |\langle \phi_{\theta}(x) | \phi_{\theta}(y) \rangle|^2
+        K_{\theta_x,\theta_y}(x,y) = |\langle \phi_{\theta_x}(x) | \phi_{\theta_y}(y) \rangle|^2
     """
 
     def __init__(
@@ -97,7 +98,55 @@ class TrainableFidelityStatevectorKernel(TrainableKernel, FidelityStatevectorKer
         ]
         self._parameter_dict = {parameter: None for parameter in self.feature_map.parameters}
 
-    def _evaluate(self, x_vec: np.ndarray, y_vec: np.ndarray, is_symmetric: bool):
-        new_x_vec = self._parameter_array(x_vec)
-        new_y_vec = self._parameter_array(y_vec)
+    def _evaluate(
+            self, 
+            x_vec: np.ndarray, 
+            y_vec: np.ndarray, 
+            is_symmetric: bool, 
+            x_parameters: np.ndarray | None = None, 
+            y_parameters: np.ndarray | None = None
+    ):
+        new_x_vec = self._parameter_array(x_vec, x_parameters)
+        new_y_vec = self._parameter_array(y_vec, y_parameters)
         return super()._evaluate(new_x_vec, new_y_vec, is_symmetric)
+
+    def evaluate(
+            self, 
+            x_vec: np.ndarray, 
+            y_vec: np.ndarray | None = None,
+            x_parameters: np.ndarray | None = None, 
+            y_parameters: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """
+        Evaluate the kernel matrix.
+
+        Args:
+            x_vec: Input data for the left feature map.
+            y_vec: Input data for the right feature map.
+            x_parameters: Training parameter values for the left feature map.
+            y_parameters: Training parameter values for the right feature map.
+
+        Returns:
+            The evaluated kernel matrix.
+        """
+        if self._auto_clear_cache:
+            self.clear_cache()
+
+        x_vec, y_vec = self._validate_input(x_vec, y_vec)
+
+        # determine if calculating self inner product
+        if y_vec is None:
+            y_vec = x_vec
+
+        x_parameter_values = self.parameter_values if x_parameters is None else x_parameters
+        y_parameter_values = self.parameter_values if y_parameters is None else y_parameters
+
+        is_symmetric = np.array_equal(x_vec, y_vec) and np.array_equal(x_parameter_values, y_parameter_values)
+
+        return self._evaluate(
+            x_vec,
+            y_vec,
+            is_symmetric,
+            x_parameters,
+            y_parameters,
+        )

--- a/qiskit_machine_learning/kernels/trainable_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_kernel.py
@@ -56,11 +56,7 @@ class TrainableKernel(BaseKernel, ABC):
         Fix the training parameters to numerical values.
         """
         if not isinstance(parameter_values, dict):
-            if len(parameter_values) != self._num_training_parameters:
-                raise ValueError(
-                    f"The number of given parameters is wrong: {len(parameter_values)}, "
-                    f"expected {self._num_training_parameters}."
-                )
+            self._check_trainable_parameters(parameter_values)
             self._parameter_dict.update(
                 {
                     parameter: parameter_values[i]
@@ -98,24 +94,49 @@ class TrainableKernel(BaseKernel, ABC):
         """
         return len(self._training_parameters)
 
-    def _parameter_array(self, x_vec: np.ndarray) -> np.ndarray:
+    def _parameter_array(self, x_vec: np.ndarray, x_parameters: np.ndarray | None = None) -> np.ndarray:
         """
         Combines the feature values and the trainable parameters into one array.
+
+        Args:
+            x_vec: Input feature values.
+            x_parameters: Training parameter values.
+
+        Returns:
+            The combined feature and training parameter values.
         """
-        self._check_trainable_parameters()
+        
+        if x_parameters is None:
+            self._check_trainable_parameters()
+            parameter_dict = self._parameter_dict.copy()
+        else:
+            self._check_trainable_parameters(x_parameters)
+            parameter_dict = self._parameter_dict.copy()
+
+            for parameter, value in zip(self._training_parameters, x_parameters):
+                parameter_dict[parameter] = value
+
         full_array = np.zeros((x_vec.shape[0], self._num_features + self._num_training_parameters))
         for i, x in enumerate(x_vec):
-            self._parameter_dict.update(
+            parameter_dict.update(
                 {feature_param: x[j] for j, feature_param in enumerate(self._feature_parameters)}
             )
-            full_array[i, :] = list(self._parameter_dict.values())
+            full_array[i, :] = list(parameter_dict.values())
+
         return full_array
 
-    def _check_trainable_parameters(self) -> None:
-        for param in self._training_parameters:
-            if self._parameter_dict[param] is None:
-                raise QiskitMachineLearningError(
-                    f"Trainable parameter {param} has not been bound. Make sure to bind all"
-                    "trainable parameters to numerical values using `.assign_training_parameters()`"
-                    "before calling `.evaluate()`."
+    def _check_trainable_parameters(self,  parameter_values: Sequence[ParameterValueType] | np.ndarray | None = None) -> None:
+        if parameter_values is None:
+            for param in self._training_parameters:
+                if self._parameter_dict[param] is None:
+                    raise QiskitMachineLearningError(
+                        f"Trainable parameter {param} has not been bound. Make sure to bind all"
+                        "trainable parameters to numerical values using `.assign_training_parameters()`"
+                        "before calling `.evaluate()`."
+                    )
+        else:
+            if len(parameter_values) != self._num_training_parameters:
+                raise ValueError(
+                    f"The number of given parameters is wrong: {len(parameter_values)}, "
+                    f"expected {self._num_training_parameters}."
                 )

--- a/qiskit_machine_learning/kernels/trainable_kernel.py
+++ b/qiskit_machine_learning/kernels/trainable_kernel.py
@@ -55,7 +55,7 @@ class TrainableKernel(BaseKernel, ABC):
         """
         Fix the training parameters to numerical values.
         """
-        if not isinstance(parameter_values, dict):
+        if not isinstance(parameter_values, Mapping):
             self._check_trainable_parameters(parameter_values)
             self._parameter_dict.update(
                 {
@@ -94,7 +94,9 @@ class TrainableKernel(BaseKernel, ABC):
         """
         return len(self._training_parameters)
 
-    def _parameter_array(self, x_vec: np.ndarray, x_parameters: np.ndarray | None = None) -> np.ndarray:
+    def _parameter_array(
+        self, x_vec: np.ndarray, x_parameters: np.ndarray | None = None
+    ) -> np.ndarray:
         """
         Combines the feature values and the trainable parameters into one array.
 
@@ -105,7 +107,7 @@ class TrainableKernel(BaseKernel, ABC):
         Returns:
             The combined feature and training parameter values.
         """
-        
+
         if x_parameters is None:
             self._check_trainable_parameters()
             parameter_dict = self._parameter_dict.copy()
@@ -125,7 +127,9 @@ class TrainableKernel(BaseKernel, ABC):
 
         return full_array
 
-    def _check_trainable_parameters(self,  parameter_values: Sequence[ParameterValueType] | np.ndarray | None = None) -> None:
+    def _check_trainable_parameters(
+        self, parameter_values: Sequence[ParameterValueType] | np.ndarray | None = None
+    ) -> None:
         if parameter_values is None:
             for param in self._training_parameters:
                 if self._parameter_dict[param] is None:

--- a/releasenotes/notes/feat-pegasos-qka-f7e81223fe832fab.yaml
+++ b/releasenotes/notes/feat-pegasos-qka-f7e81223fe832fab.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added the Pegasos quantum kernel alignment classifier, which extends the 
+    Pegasos quantum support vector classifier with quantum kernel alignment. 
+    PegasosQKA optimizes both the parameters of a trainable quantum kernel and 
+    the weights of the SVC during the same optimization loop.
+
+    Trainable quantum kernels now support evaluating trainable kernels with
+    independent left and right parameter values.

--- a/test/algorithms/classifiers/test_fidelity_quantum_kernel_pegasos_qka.py
+++ b/test/algorithms/classifiers/test_fidelity_quantum_kernel_pegasos_qka.py
@@ -1,0 +1,300 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2026.
+# (C) Copyright UKRI-STFC (Hartree Centre) 2026.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Pegasos QKA"""
+
+import unittest
+from unittest.mock import patch
+
+from test import QiskitMachineLearningTestCase
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import z_feature_map
+from qiskit.primitives import StatevectorSampler as Sampler
+from qiskit.circuit import ParameterVector
+
+from sklearn.datasets import make_blobs
+from sklearn.preprocessing import MinMaxScaler
+
+from qiskit_machine_learning.utils import algorithm_globals
+from qiskit_machine_learning.algorithms import PegasosQKA
+from qiskit_machine_learning.kernels import TrainableFidelityQuantumKernel
+from qiskit_machine_learning import QiskitMachineLearningError
+from qiskit_machine_learning.state_fidelities import ComputeUncompute
+
+
+class TestPegasosQKA(QiskitMachineLearningTestCase):
+    """Test Pegasos QKA Algorithm"""
+
+    def setUp(self):
+        super().setUp()
+
+        algorithm_globals.random_seed = 10598
+
+        # number of qubits is equal to the number of features
+        self.q = 2
+        # number of steps performed during the training procedure
+        self.tau = 100
+
+        z_map = z_feature_map(feature_dimension=self.q, reps=1)
+
+        # Create a rotational layer to train.
+        self.training_params = ParameterVector("θ", 1)
+        fm = QuantumCircuit(2)
+        fm.ry(self.training_params[0], 0)
+        fm.ry(self.training_params[0], 1)
+
+        # Create the feature map, composed of our two circuits
+        self.feature_map = fm.compose(z_map)
+
+        self.sampler = Sampler()
+        self.fidelity = ComputeUncompute(sampler=self.sampler)
+        self.qkernel = TrainableFidelityQuantumKernel(
+            fidelity=self.fidelity,
+            feature_map=self.feature_map,
+            training_parameters=self.training_params,
+        )
+
+        sample, label = make_blobs(
+            n_samples=20, n_features=2, centers=2, random_state=3, shuffle=True
+        )
+        sample = MinMaxScaler(feature_range=(0, np.pi)).fit_transform(sample)
+
+        # split into train and test set
+        self.sample_train = sample[:15]
+        self.label_train = label[:15]
+        self.sample_test = sample[15:]
+        self.label_test = label[15:]
+
+    def test_qka(self):
+        """Test PegasosQKA"""
+
+        pegasos_qka = PegasosQKA(quantum_kernel=self.qkernel, C=1000, num_steps=self.tau)
+
+        pegasos_qka.fit(self.sample_train, self.label_train)
+        score = pegasos_qka.score(self.sample_test, self.label_test)
+
+        self.assertEqual(score, 1.0)
+
+    def test_constructor(self):
+        """Tests properties of PegasosQKA"""
+        with self.subTest("Default parameters"):
+            with self.assertRaises(QiskitMachineLearningError):
+                pegasos_qka = PegasosQKA()
+
+        with self.subTest("Default initial thetas"):
+            pegasos_qka = PegasosQKA(
+                quantum_kernel=self.qkernel,
+                C=1000,
+                num_steps=self.tau,
+            )
+
+            np.testing.assert_array_equal(
+                pegasos_qka._theta,
+                np.zeros(len(self.training_params)),
+            )
+
+        with self.subTest("Specified initial thetas"):
+            initial_thetas = np.full(len(self.training_params), 0.5)
+
+            pegasos_qka = PegasosQKA(
+                quantum_kernel=self.qkernel,
+                C=1000,
+                num_steps=self.tau,
+                initial_thetas=initial_thetas,
+            )
+
+            np.testing.assert_array_equal(
+                pegasos_qka._theta,
+                initial_thetas,
+            )
+
+        with self.subTest("Incorrect initial theta"):
+            with self.assertRaises(ValueError):
+                PegasosQKA(
+                    quantum_kernel=self.qkernel,
+                    initial_thetas=np.zeros(len(self.training_params) + 1),
+                )
+
+        with self.subTest("PegasosQKA with TrainableFidelityQuantumKernel"):
+
+            pegasos_qka = PegasosQKA(quantum_kernel=self.qkernel, C=1000, num_steps=self.tau)
+            self.assertIsInstance(pegasos_qka.quantum_kernel, TrainableFidelityQuantumKernel)
+            self.assertEqual(
+                pegasos_qka.quantum_kernel.num_training_parameters,
+                len(self.training_params),
+            )
+
+    def test_theta_update(self):
+        """Test theta update."""
+
+        pegasos_qka = PegasosQKA(
+            quantum_kernel=self.qkernel,
+            C=1,
+            num_steps=self.tau,
+            learning_rate=0.1,
+            perturbations=0.1,
+        )  # theta -> all zeros
+
+        pegasos_qka._label_map = {0: -1, 1: 1}
+        pegasos_qka._alphas = {}
+
+        # set bernoulli_perturbation
+        perturbation = np.ones(len(self.training_params))
+
+        with patch(
+            "qiskit_machine_learning.algorithms.classifiers.pegasos_qka.bernoulli_perturbation",
+            return_value=perturbation,
+        ):
+            # value = self._compute_weighted_kernel_sum(index, X, training=True)
+            # obj = -factor * self._compute_weighted_kernel_sum(index, X, training=True)
+            pegasos_qka._compute_weighted_kernel_sum = unittest.mock.Mock(
+                side_effect=[0.0, 0.2, 0.0]  # value, obj_plus, obj_minus
+            )
+
+            pegasos_qka._update_step(
+                0, self.sample_train, np.ones(len(self.sample_train), dtype=int), 1
+            )
+            # check (y_step * self.C / step) * value < 1 --> True
+            # factor = y_step * self.C / step
+            # gradient = (obj_plus - obj_minus) / (2 * learning_rate)
+
+        # new_theta = new_theta - learning_rate * gradient * perturbation
+        expected_theta = np.full(len(self.training_params), 0.1)
+        np.testing.assert_array_equal(pegasos_qka._theta, expected_theta)
+
+        # self._alphas[index] = self._alphas.get(index, 0) + 1
+        self.assertEqual(pegasos_qka._alphas[0], 1)
+
+        # self._support_thetas[index].append(support_theta)
+        np.testing.assert_array_equal(
+            pegasos_qka._support_thetas[0][0],
+            np.zeros(len(self.training_params)),
+        )
+
+    def test_no_theta_update(self):
+        """Test theta is not updated when margin condition is satisfied."""
+
+        pegasos_qka = PegasosQKA(
+            quantum_kernel=self.qkernel,
+            C=1,
+            num_steps=self.tau,
+            learning_rate=0.1,
+        )
+
+        pegasos_qka._label_map = {0: -1, 1: 1}
+        pegasos_qka._alphas = {}
+
+        initial_theta = pegasos_qka._theta.copy()
+
+        pegasos_qka._compute_weighted_kernel_sum = unittest.mock.Mock(return_value=2.0)
+
+        pegasos_qka._update_step(
+            0,
+            self.sample_train,
+            np.ones(len(self.sample_train), dtype=int),
+            1,
+        )
+        # check (y_step * self.C / step) * value < 1 --> False
+        # = no update
+        np.testing.assert_array_equal(pegasos_qka._theta, initial_theta)
+        self.assertEqual(pegasos_qka._alphas, {})
+        self.assertEqual(pegasos_qka._support_thetas, {})
+
+    def test_support_thetas(self):
+        """Test support theta history."""
+
+        pegasos_qka = PegasosQKA(
+            quantum_kernel=self.qkernel,
+            C=1,
+            num_steps=self.tau,
+            learning_rate=0.1,
+            perturbations=0.1,
+        )
+
+        pegasos_qka._label_map = {0: -1, 1: 1}
+        pegasos_qka._alphas = {}
+
+        # set bernoulli_perturbation
+        perturbation = np.ones(len(self.training_params))
+
+        with patch(
+            "qiskit_machine_learning.algorithms.classifiers.pegasos_qka.bernoulli_perturbation",
+            return_value=perturbation,
+        ):
+            pegasos_qka._compute_weighted_kernel_sum = unittest.mock.Mock(
+                side_effect=[
+                    0.0,
+                    0.2,
+                    0.0,
+                    0.0,
+                    0.2,
+                    0.0,
+                ]
+            )
+
+            y = np.ones(len(self.sample_train), dtype=int)
+
+            pegasos_qka._update_step(0, self.sample_train, y, 1)
+            pegasos_qka._update_step(0, self.sample_train, y, 2)
+
+        self.assertEqual(len(pegasos_qka._support_thetas[0]), 2)
+
+        np.testing.assert_array_equal(
+            pegasos_qka._support_thetas[0][0],
+            np.zeros(len(self.training_params)),
+        )
+
+        np.testing.assert_array_equal(
+            pegasos_qka._support_thetas[0][1],
+            np.full(len(self.training_params), 0.1),
+        )
+
+        self.assertEqual(pegasos_qka._alphas[0], 2)
+
+    def test_evaluate_kernel(self):
+        """Test kernel evaluation over support theta history."""
+
+        pegasos_qka = PegasosQKA(
+            quantum_kernel=self.qkernel,
+            C=1,
+            num_steps=self.tau,
+        )
+
+        pegasos_qka._left_theta = np.zeros(len(self.training_params))
+        pegasos_qka._kernel_offset = 1
+        support_indices = [0, 1]
+
+        pegasos_qka._support_thetas = {
+            0: [
+                np.zeros(len(self.training_params)),
+                np.full(len(self.training_params), 0.1),
+            ],
+            1: [
+                np.full(len(self.training_params), 0.2),
+            ],
+        }
+
+        pegasos_qka._quantum_kernel.evaluate = unittest.mock.Mock(side_effect=[0.2, 0.4, 0.8])
+
+        values = pegasos_qka._evaluate_kernel(
+            self.sample_test[0],
+            self.sample_train[:2],
+            support_indices,
+        )
+
+        expected = np.array([1.3, 1.8])
+
+        np.testing.assert_allclose(values, expected)
+        self.assertEqual(pegasos_qka._quantum_kernel.evaluate.call_count, 3)

--- a/test/kernels/test_trainable_fidelity_qkernel.py
+++ b/test/kernels/test_trainable_fidelity_qkernel.py
@@ -193,6 +193,97 @@ class TestPrimitivesTrainableQuantumKernelClassify(QiskitMachineLearningTestCase
             with self.assertRaises(QiskitMachineLearningError):
                 _ = trainable_kernel_type(feature_map=None)
 
+    @idata(
+        itertools.product(
+            [TrainableFidelityQuantumKernel, TrainableFidelityStatevectorKernel],
+            [
+                ([0.0, 0.0, 0.0], [[1.0, 0.03351197], [0.03351197, 1.0]]),
+                ([0.1, 0.531, 4.12], [[1.0, 0.082392], [0.082392, 1.0]]),
+            ],
+        )
+    )
+    @unpack
+    def test_evaluate_symmetric_with_parameters(self, trainable_kernel_type, params_solution):
+        """Test evaluation with explicitly provided training parameters."""
+        kernel = trainable_kernel_type(
+            feature_map=self.feature_map,
+            training_parameters=self.training_parameters,
+        )
+
+        kernel_matrix = kernel.evaluate(
+            self.sample_train,
+            x_parameters=params_solution[0],
+            y_parameters=params_solution[0],
+        )
+
+        np.testing.assert_allclose(kernel_matrix, params_solution[1], rtol=1e-7, atol=1e-7)
+
+    @idata(
+        itertools.product(
+            [TrainableFidelityQuantumKernel, TrainableFidelityStatevectorKernel],
+            [
+                ([0.0, 0.0, 0.0], [[0.00569059], [0.07038205]]),
+                ([0.1, 0.531, 4.12], [[0.10568674], [0.122404]]),
+            ],
+        )
+    )
+    @unpack
+    def test_evaluate_asymmetric_with_parameters(self, trainable_kernel_type, params_solution):
+        """Test asymmetric evaluation with explicitly provided training parameters."""
+        kernel = trainable_kernel_type(
+            feature_map=self.feature_map,
+            training_parameters=self.training_parameters,
+        )
+
+        kernel_matrix = kernel.evaluate(
+            self.sample_train,
+            self.sample_test,
+            x_parameters=params_solution[0],
+            y_parameters=params_solution[0],
+        )
+
+        np.testing.assert_allclose(
+            kernel_matrix,
+            params_solution[1],
+            rtol=1e-7,
+            atol=1e-7,
+        )
+
+    @idata(
+        itertools.product(
+            [TrainableFidelityQuantumKernel, TrainableFidelityStatevectorKernel],
+            [
+                ([0.0, 0.0, 0.0], [0.1, 0.531, 4.12]),
+                ([0.2, 0.4, 0.6], [0.7, 0.9, 1.1]),
+            ],
+        )
+    )
+    @unpack
+    def test_evaluate_different_parameters(self, trainable_kernel_type, parameters):
+        """Test kernel evaluation with different left and right training parameters."""
+        kernel = trainable_kernel_type(
+            feature_map=self.feature_map,
+            training_parameters=self.training_parameters,
+        )
+
+        x_parameters, y_parameters = parameters
+
+        kernel_xy = kernel.evaluate(
+            self.sample_train,
+            self.sample_train,
+            x_parameters=x_parameters,
+            y_parameters=y_parameters,
+        )
+
+        kernel_yx = kernel.evaluate(
+            self.sample_train,
+            self.sample_train,
+            x_parameters=y_parameters,
+            y_parameters=x_parameters,
+        )
+
+        np.testing.assert_allclose(kernel_xy, kernel_yx.T, rtol=1e-7, atol=1e-7)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

- PR related to #946.
- Extends the PegasosQSVC algorithm to perform quantum kernel alignment within the optimization loop.
- Based on the logic introduced in https://ieeexplore.ieee.org/document/10313634 with accompanying code https://zenodo.org/records/7804477.
- Adapts the TrainableKernel classes to allow for evaluating trainable kernels with different left and right parameters.


### Details and comments

- The majority of the PegasosQKA code follows from https://zenodo.org/records/7804477 but has been stripped back to make the implementation more streamlined.
- Decided not to include the self._blasphemy logic (computing kernel without historical thetas) as this is not how the algorithm is intended to be ran.
- Decided at this time not to include a callback however this could be a possible future feature.
- Precomputed kernel functionality is not needed for QKA since by design we change the kernel throught the algorithm.
- Decided warm starting and calibration/recalibration is not needed. It seems calibration was not used in the paper and adds a lot of extra bloat to the algorithm so I thought it was best to not include it (`learning_rate` and `perturbations` are passed as fixed variables).

- To be able to cleanly inherit PegasosQSVC I extracted the step update logic into its own function `_update_step` and also the kernel evaulation logic into `_evaluate_kernel`. This meant we can cleanly overide these in the PegasosQKA class and reuse the bulk of the QSVC algorithm.

- Previously the trainable kernels did not have the option to set seperate paramters for the left and right feature maps. The paper logic introduced a new pseudo kernel but to avoid adding this I have introduced the ability to run and evaluate the trainable kernels with the seperate left and right parameters.

**AI Disclosure** - *ChatGPT was used in this work primarily to help with producing tests and also helped me better understand the PegasosQSVC/PegasosQKA algorithms. The main body of code already existed from the paper source code and all implementation/checks were done by myself. I fully understand the code I have produced but I will note that during the process ChatGPT did help verify/clarify some of the logic I was imlpementing. *
